### PR TITLE
Updating error message for `locate()` methods.

### DIFF
--- a/src/bezier/curve.py
+++ b/src/bezier/curve.py
@@ -39,6 +39,9 @@ from bezier import _plot_helpers
 
 _REPR_TEMPLATE = (
     '<{} (degree={:d}, dimension={:d}, start={:g}, end={:g})>')
+_LOCATE_ERROR_TEMPLATE = (
+    'Dimension mismatch: This curve is {:d}-dimensional, so the point should '
+    'be a 1x{:d} NumPy array. Instead the point {} has dimensions {}.')
 _LINEAR_SUBDIVIDE_LEFT = np.asfortranarray([
     [1.0, 0.0],
     [0.5, 0.5],
@@ -374,6 +377,8 @@ class Curve(_base.Base):
 
     def evaluate(self, s):
         r"""Evaluate :math:`B(s)` along the curve.
+
+        This method acts as a (partial) inverse to :meth:`locate`.
 
         See :meth:`evaluate_multi` for more details.
 
@@ -849,6 +854,8 @@ class Curve(_base.Base):
 
         Solves for :math:`s` in :math:`B(s) = p`.
 
+        This method acts as a (partial) inverse to :meth:`evaluate`.
+
         .. note::
 
            A unique solution is only guaranteed if the current curve has no
@@ -894,7 +901,10 @@ class Curve(_base.Base):
                 dimension of the current curve.
         """
         if point.shape != (1, self._dimension):
-            raise ValueError('Point is not in same dimension as curve',
-                             point, 'Shape expected:', (1, self._dimension))
+            point_dimensions = ' x '.join(
+                str(dimension) for dimension in point.shape)
+            msg = _LOCATE_ERROR_TEMPLATE.format(
+                self._dimension, self._dimension, point, point_dimensions)
+            raise ValueError(msg)
 
         return _curve_helpers.locate_point(self, point)

--- a/src/bezier/surface.py
+++ b/src/bezier/surface.py
@@ -37,6 +37,9 @@ from bezier import curve as _curve_mod
 
 _REPR_TEMPLATE = (
     '<{} (degree={:d}, dimension={:d}, base=({:g}, {:g}), width={:g})>')
+_LOCATE_ERROR_TEMPLATE = (
+    'Dimension mismatch: This surface is {:d}-dimensional, so the point '
+    'should be a 1x{:d} NumPy array. Instead the point {} has dimensions {}.')
 _STRATEGY = _intersection_helpers.IntersectionStrategy
 
 
@@ -670,6 +673,8 @@ class Surface(_base.Base):
         Evaluates :math:`B\left(1 - s - t, s, t\right)` by calling
         :meth:`evaluate_barycentric`:
 
+        This method acts as a (partial) inverse to :meth:`locate`.
+
         .. testsetup:: surface-cartesian
 
            import numpy as np
@@ -1066,6 +1071,8 @@ class Surface(_base.Base):
 
         Solves for :math:`s` and :math:`t` in :math:`B(s, t) = p`.
 
+        This method acts as a (partial) inverse to :meth:`evaluate_cartesian`.
+
         .. note::
 
            A unique solution is only guaranteed if the current surface is
@@ -1119,9 +1126,11 @@ class Surface(_base.Base):
                 raise NotImplementedError('Only 2D surfaces supported.')
 
             if point.shape != (1, self._dimension):
-                raise ValueError('Point is not in same dimension as surface',
-                                 point, 'Shape expected:',
-                                 (1, self._dimension))
+                point_dimensions = ' x '.join(
+                    str(dimension) for dimension in point.shape)
+                msg = _LOCATE_ERROR_TEMPLATE.format(
+                    self._dimension, self._dimension, point, point_dimensions)
+                raise ValueError(msg)
 
         return _surface_helpers.locate_point(self, point[0, 0], point[0, 1])
 


### PR DESCRIPTION
Also adding a note that `locate()` / `evaluate*()` are (essentially) inverses.

See #35 for context.

/cc @pdknsk 

Old error:

```python
>>> import numpy as np
>>> import bezier
>>> curve = bezier.Curve.from_nodes(np.asfortranarray([
...     [0.0, 0.0],
...     [0.5, 0.0],
...     [0.5, 1.0],
...     [1.0, 1.0],
... ]), _copy=False)
>>> curve.evaluate(0.5)
array([[ 0.5,  0.5]])
>>> curve.locate(np.asfortranarray([[0.5]]))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File ".../bezier/curve.py", line 898, in locate
    point, 'Shape expected:', (1, self._dimension))
ValueError: ('Point is not in same dimension as curve', array([[ 0.5]]), 
             'Shape expected:', (1, 2))
```

New error:

```python
>>> curve.locate(np.asfortranarray([[0.5]]))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File ".../bezier/curve.py", line 908, in locate
    raise ValueError(msg)
ValueError: Dimension mismatch: This curve is 2-dimensional, so the point should be
            a 1x2 NumPy array. Instead the point [[ 0.5]] has dimensions 1 x 1.
```