### PR TITLE
Use `BEZ_` prefix for exported C ABI names

### DIFF
--- a/docs/abi/curve.rst
+++ b/docs/abi/curve.rst
@@ -14,11 +14,11 @@ B |eacute| zier `curve`_.
 Procedures
 **********
 
-.. c:function:: void compute_length(int *num_nodes, \
-                                    int *dimension, \
-                                    double *nodes, \
-                                    double *length, \
-                                    int *error_val)
+.. c:function:: void BEZ_compute_length(int *num_nodes, \
+                                        int *dimension, \
+                                        double *nodes, \
+                                        double *length, \
+                                        int *error_val)
 
    Computes the length of a B |eacute| zier curve via
 
@@ -47,11 +47,11 @@ Procedures
    .. code-block:: c
 
       void
-      compute_length(int *num_nodes,
-                     int *dimension,
-                     double *nodes,
-                     double *length,
-                     int *error_val);
+      BEZ_compute_length(int *num_nodes,
+                         int *dimension,
+                         double *nodes,
+                         double *length,
+                         int *error_val);
 
    **Example:**
 
@@ -76,10 +76,10 @@ Procedures
       Length: 5.000000
       Error value: 0
 
-.. c:function:: void elevate_nodes_curve(int *num_nodes, \
-                                         int *dimension, \
-                                         double *nodes, \
-                                         double *elevated)
+.. c:function:: void BEZ_elevate_nodes_curve(int *num_nodes, \
+                                             int *dimension, \
+                                             double *nodes, \
+                                             double *elevated)
 
    Degree-elevate a B |eacute| zier curve. Does so by producing
    control points of a higher degree that define the exact same curve.
@@ -105,10 +105,10 @@ Procedures
    .. code-block:: c
 
       void
-      elevate_nodes_curve(int *num_nodes,
-                          int *dimension,
-                          double *nodes,
-                          double *elevated);
+      BEZ_elevate_nodes_curve(int *num_nodes,
+                              int *dimension,
+                              double *nodes,
+                              double *elevated);
 
    **Example:**
 
@@ -145,13 +145,13 @@ Procedures
    .. image:: ../images/curve_elevate.png
       :align: center
 
-.. c:function:: void evaluate_curve_barycentric(int *num_nodes, \
-                                                int *dimension, \
-                                                double *nodes, \
-                                                int *num_vals, \
-                                                double *lambda1, \
-                                                double *lambda2, \
-                                                double *evaluated)
+.. c:function:: void BEZ_evaluate_curve_barycentric(int *num_nodes, \
+                                                    int *dimension, \
+                                                    double *nodes, \
+                                                    int *num_vals, \
+                                                    double *lambda1, \
+                                                    double *lambda2, \
+                                                    double *evaluated)
 
    For a B |eacute| zier curve with control points :math:`p_0, \ldots, p_d`,
    this evaluates the quantity
@@ -193,13 +193,13 @@ Procedures
    .. code-block:: c
 
       void
-      evaluate_curve_barycentric(int *num_nodes,
-                                 int *dimension,
-                                 double *nodes,
-                                 int *num_vals,
-                                 double *lambda1,
-                                 double *lambda2,
-                                 double *evaluated);
+      BEZ_evaluate_curve_barycentric(int *num_nodes,
+                                     int *dimension,
+                                     double *nodes,
+                                     int *num_vals,
+                                     double *lambda1,
+                                     double *lambda2,
+                                     double *evaluated);
 
    **Example:**
 
@@ -243,11 +243,11 @@ Procedures
       2.437500, 0.687500, 0.750000, 1.187500
       2.125000, 0.687500, 0.750000, 1.687500
 
-.. c:function:: void evaluate_hodograph(double *s, \
-                                        int *num_nodes, \
-                                        int *dimension, \
-                                        double *nodes, \
-                                        double *hodograph)
+.. c:function:: void BEZ_evaluate_hodograph(double *s, \
+                                            int *num_nodes, \
+                                            int *dimension, \
+                                            double *nodes, \
+                                            double *hodograph)
 
    Evaluates the hodograph (or derivative) of a B |eacute| zier curve
    function :math:`B'(s)`.
@@ -273,11 +273,11 @@ Procedures
    .. code-block:: c
 
       void
-      evaluate_hodograph(double *s,
-                         int *num_nodes,
-                         int *dimension,
-                         double *nodes,
-                         double *hodograph);
+      BEZ_evaluate_hodograph(double *s,
+                             int *num_nodes,
+                             int *dimension,
+                             double *nodes,
+                             double *hodograph);
 
    **Example:**
 
@@ -309,12 +309,12 @@ Procedures
       0.656250
       1.687500
 
-.. c:function:: void evaluate_multi(int *num_nodes, \
-                                    int *dimension, \
-                                    double *nodes, \
-                                    int *num_vals, \
-                                    double *s_vals, \
-                                    double *evaluated)
+.. c:function:: void BEZ_evaluate_multi(int *num_nodes, \
+                                        int *dimension, \
+                                        double *nodes, \
+                                        int *num_vals, \
+                                        double *s_vals, \
+                                        double *evaluated)
 
    Evaluate a B |eacute| zier curve function :math:`B(s_j)` at
    multiple values :math:`\left\{s_j\right\}_j`.
@@ -344,12 +344,12 @@ Procedures
    .. code-block:: c
 
       void
-      evaluate_multi(int *num_nodes,
-                     int *dimension,
-                     double *nodes,
-                     int *num_vals,
-                     double *s_vals,
-                     double *evaluated);
+      BEZ_evaluate_multi(int *num_nodes,
+                         int *dimension,
+                         double *nodes,
+                         int *num_vals,
+                         double *s_vals,
+                         double *evaluated);
 
    **Example:**
 
@@ -383,12 +383,12 @@ Procedures
       1.000000, 1.500000, 2.000000
       0.000000, 0.500000, 1.000000
 
-.. c:function:: void full_reduce(int *num_nodes, \
-                                 int *dimension, \
-                                 double *nodes, \
-                                 int *num_reduced_nodes, \
-                                 double *reduced, \
-                                 bool *not_implemented)
+.. c:function:: void BEZ_full_reduce(int *num_nodes, \
+                                     int *dimension, \
+                                     double *nodes, \
+                                     int *num_reduced_nodes, \
+                                     double *reduced, \
+                                     bool *not_implemented)
 
    Perform a "full" degree reduction. Does so by using
    :c:func:`reduce_pseudo_inverse` continually until the degree of
@@ -423,12 +423,12 @@ Procedures
    .. code-block:: c
 
       void
-      full_reduce(int *num_nodes,
-                  int *dimension,
-                  double *nodes,
-                  int *num_reduced_nodes,
-                  double *reduced,
-                  bool *not_implemented);
+      BEZ_full_reduce(int *num_nodes,
+                      int *dimension,
+                      double *nodes,
+                      int *num_reduced_nodes,
+                      double *reduced,
+                      bool *not_implemented);
 
    **Example:**
 
@@ -461,11 +461,11 @@ Procedures
       3.000000, 5.000000
       Not implemented: FALSE
 
-.. c:function:: void get_curvature(int *num_nodes, \
-                                   double *nodes, \
-                                   double *tangent_vec, \
-                                   double *s, \
-                                   double *curvature)
+.. c:function:: void BEZ_get_curvature(int *num_nodes, \
+                                       double *nodes, \
+                                       double *tangent_vec, \
+                                       double *s, \
+                                       double *curvature)
 
    Get the signed curvature of a B |eacute| zier curve at a point. See
    :func:`._py_curve_helpers.get_curvature` for more details.
@@ -498,11 +498,11 @@ Procedures
    .. code-block:: c
 
       void
-      get_curvature(int *num_nodes,
-                    double *nodes,
-                    double *tangent_vec,
-                    double *s,
-                    double *curvature);
+      BEZ_get_curvature(int *num_nodes,
+                        double *nodes,
+                        double *tangent_vec,
+                        double *s,
+                        double *curvature);
 
    **Example:**
 
@@ -526,11 +526,11 @@ Procedures
       $ ./example
       Curvature: -12.000000
 
-.. c:function:: void locate_point_curve(int *num_nodes, \
-                                        int *dimension, \
-                                        double *nodes, \
-                                        double *point, \
-                                        double *s_approx)
+.. c:function:: void BEZ_locate_point_curve(int *num_nodes, \
+                                            int *dimension, \
+                                            double *nodes, \
+                                            double *point, \
+                                            double *s_approx)
 
    This solves the inverse problem :math:`B(s) = p` (if it can be
    solved). Does so by subdividing the curve until the segments are
@@ -561,11 +561,11 @@ Procedures
    .. code-block:: c
 
       void
-      locate_point_curve(int *num_nodes,
-                         int *dimension,
-                         double *nodes,
-                         double *point,
-                         double *s_approx);
+      BEZ_locate_point_curve(int *num_nodes,
+                             int *dimension,
+                             double *nodes,
+                             double *point,
+                             double *s_approx);
 
    **Example:**
 
@@ -610,12 +610,12 @@ Procedures
    .. image:: ../images/curve_locate.png
       :align: center
 
-.. c:function:: void newton_refine_curve(int *num_nodes, \
-                                         int *dimension, \
-                                         double *nodes, \
-                                         double *point, \
-                                         double *s, \
-                                         double *updated_s)
+.. c:function:: void BEZ_newton_refine_curve(int *num_nodes, \
+                                             int *dimension, \
+                                             double *nodes, \
+                                             double *point, \
+                                             double *s, \
+                                             double *updated_s)
 
    This refines a solution to :math:`B(s) = p` using Newton's
    method. Given a current approximation :math:`s_n` for a solution,
@@ -650,12 +650,12 @@ Procedures
    .. code-block:: c
 
       void
-      newton_refine_curve(int *num_nodes,
-                          int *dimension,
-                          double *nodes,
-                          double *point,
-                          double *s,
-                          double *updated_s);
+      BEZ_newton_refine_curve(int *num_nodes,
+                              int *dimension,
+                              double *nodes,
+                              double *point,
+                              double *s,
+                              double *updated_s);
 
    **Example:**
 
@@ -689,11 +689,11 @@ Procedures
    .. image:: ../images/newton_refine_curve.png
       :align: center
 
-.. c:function:: void reduce_pseudo_inverse(int *num_nodes, \
-                                           int *dimension, \
-                                           double *nodes, \
-                                           double *reduced, \
-                                           bool *not_implemented)
+.. c:function:: void BEZ_reduce_pseudo_inverse(int *num_nodes, \
+                                               int *dimension, \
+                                               double *nodes, \
+                                               double *reduced, \
+                                               bool *not_implemented)
 
    Perform a pseudo inverse to :c:func:`elevate_nodes_curve`. If an
    inverse can be found, i.e. if a curve can be degree-reduced, then
@@ -724,11 +724,11 @@ Procedures
    .. code-block:: c
 
       void
-      reduce_pseudo_inverse(int *num_nodes,
-                            int *dimension,
-                            double *nodes,
-                            double *reduced,
-                            bool *not_implemented);
+      BEZ_reduce_pseudo_inverse(int *num_nodes,
+                                int *dimension,
+                                double *nodes,
+                                double *reduced,
+                                bool *not_implemented);
 
    **Example:**
 
@@ -765,12 +765,12 @@ Procedures
    .. image:: ../images/curve_reduce.png
       :align: center
 
-.. c:function:: void specialize_curve(int *num_nodes, \
-                                      int *dimension, \
-                                      double *nodes, \
-                                      double *start, \
-                                      double *end, \
-                                      double *new_nodes)
+.. c:function:: void BEZ_specialize_curve(int *num_nodes, \
+                                          int *dimension, \
+                                          double *nodes, \
+                                          double *start, \
+                                          double *end, \
+                                          double *new_nodes)
 
    Specialize a B |eacute| zier curve to an interval
    :math:`\left[a, b\right]`. This produces the control points
@@ -799,12 +799,12 @@ Procedures
    .. code-block:: c
 
       void
-      specialize_curve(int *num_nodes,
-                       int *dimension,
-                       double *nodes,
-                       double *start,
-                       double *end,
-                       double *new_nodes);
+      BEZ_specialize_curve(int *num_nodes,
+                           int *dimension,
+                           double *nodes,
+                           double *start,
+                           double *end,
+                           double *new_nodes);
 
    **Example:**
 
@@ -844,11 +844,11 @@ Procedures
    .. image:: ../images/curve_specialize.png
       :align: center
 
-.. c:function:: void subdivide_nodes_curve(int *num_nodes, \
-                                           int *dimension, \
-                                           double *nodes, \
-                                           double *left_nodes, \
-                                           double *right_nodes)
+.. c:function:: void BEZ_subdivide_nodes_curve(int *num_nodes, \
+                                               int *dimension, \
+                                               double *nodes, \
+                                               double *left_nodes, \
+                                               double *right_nodes)
 
    Split a B |eacute| zier curve into two halves
    :math:`B\left(\left[0, \frac{1}{2}\right]\right)` and
@@ -878,11 +878,11 @@ Procedures
    .. code-block:: c
 
       void
-      subdivide_nodes_curve(int *num_nodes,
-                            int *dimension,
-                            double *nodes,
-                            double *left_nodes,
-                            double *right_nodes);
+      BEZ_subdivide_nodes_curve(int *num_nodes,
+                                int *dimension,
+                                double *nodes,
+                                double *left_nodes,
+                                double *right_nodes);
 
    **Example:**
 

--- a/docs/abi/curve.rst
+++ b/docs/abi/curve.rst
@@ -68,7 +68,7 @@ Procedures
       $ gcc \
       >   -o example \
       >   example_compute_length.c \
-      >   -I src/fortran/include/ \
+      >   -I .../src/fortran/include \
       >   -L .../site-packages/bezier/lib \
       >   -lbezier \
       >   -lm -lgfortran
@@ -133,7 +133,7 @@ Procedures
       $ gcc \
       >   -o example \
       >   example_elevate_nodes_curve.c \
-      >   -I src/fortran/include/ \
+      >   -I .../src/fortran/include \
       >   -L .../site-packages/bezier/lib \
       >   -lbezier \
       >   -lm -lgfortran
@@ -234,7 +234,7 @@ Procedures
       $ gcc \
       >   -o example \
       >   example_evaluate_curve_barycentric.c \
-      >   -I src/fortran/include/ \
+      >   -I .../src/fortran/include \
       >   -L .../site-packages/bezier/lib \
       >   -lbezier \
       >   -lm -lgfortran
@@ -300,7 +300,7 @@ Procedures
       $ gcc \
       >   -o example \
       >   example_evaluate_hodograph.c \
-      >   -I src/fortran/include/ \
+      >   -I .../src/fortran/include \
       >   -L .../site-packages/bezier/lib \
       >   -lbezier \
       >   -lm -lgfortran
@@ -374,7 +374,7 @@ Procedures
       $ gcc \
       >   -o example \
       >   example_evaluate_multi.c \
-      >   -I src/fortran/include/ \
+      >   -I .../src/fortran/include \
       >   -L .../site-packages/bezier/lib \
       >   -lbezier \
       >   -lm -lgfortran
@@ -391,7 +391,7 @@ Procedures
                                      bool *not_implemented)
 
    Perform a "full" degree reduction. Does so by using
-   :c:func:`reduce_pseudo_inverse` continually until the degree of
+   :c:func:`BEZ_reduce_pseudo_inverse` continually until the degree of
    the curve can no longer be reduced.
 
    :param int* num_nodes:
@@ -450,7 +450,7 @@ Procedures
       $ gcc \
       >   -o example \
       >   example_full_reduce.c \
-      >   -I src/fortran/include/ \
+      >   -I .../src/fortran/include \
       >   -L .../site-packages/bezier/lib \
       >   -lbezier \
       >   -lm -lgfortran
@@ -519,7 +519,7 @@ Procedures
       $ gcc \
       >   -o example \
       >   example_get_curvature.c \
-      >   -I src/fortran/include/ \
+      >   -I .../src/fortran/include \
       >   -L .../site-packages/bezier/lib \
       >   -lbezier \
       >   -lm -lgfortran
@@ -598,7 +598,7 @@ Procedures
       $ gcc \
       >   -o example \
       >   example_locate_point_curve.c \
-      >   -I src/fortran/include/ \
+      >   -I .../src/fortran/include \
       >   -L .../site-packages/bezier/lib \
       >   -lbezier \
       >   -lm -lgfortran
@@ -679,7 +679,7 @@ Procedures
       $ gcc \
       >   -o example \
       >   example_newton_refine_curve.c \
-      >   -I src/fortran/include/ \
+      >   -I .../src/fortran/include \
       >   -L .../site-packages/bezier/lib \
       >   -lbezier \
       >   -lm -lgfortran
@@ -695,7 +695,7 @@ Procedures
                                                double *reduced, \
                                                bool *not_implemented)
 
-   Perform a pseudo inverse to :c:func:`elevate_nodes_curve`. If an
+   Perform a pseudo inverse to :c:func:`BEZ_elevate_nodes_curve`. If an
    inverse can be found, i.e. if a curve can be degree-reduced, then
    this will produce the equivalent curve of lower degree. If no
    inverse can be found, then this will produce the "best" answer in
@@ -752,7 +752,7 @@ Procedures
       $ gcc \
       >   -o example \
       >   example_reduce_pseudo_inverse.c \
-      >   -I src/fortran/include/ \
+      >   -I .../src/fortran/include \
       >   -L .../site-packages/bezier/lib \
       >   -lbezier \
       >   -lm -lgfortran
@@ -831,8 +831,8 @@ Procedures
 
       $ gcc \
       >   -o example \
-      >   example_curve_specialize.c \
-      >   -I src/fortran/include/ \
+      >   example_specialize_curve.c \
+      >   -I .../src/fortran/include \
       >   -L .../site-packages/bezier/lib \
       >   -lbezier \
       >   -lm -lgfortran
@@ -903,7 +903,7 @@ Procedures
       $ gcc \
       >   -o example \
       >   example_subdivide_nodes_curve.c \
-      >   -I src/fortran/include/ \
+      >   -I .../src/fortran/include \
       >   -L .../site-packages/bezier/lib \
       >   -lbezier \
       >   -lm -lgfortran

--- a/docs/abi/curve_intersection.rst
+++ b/docs/abi/curve_intersection.rst
@@ -12,11 +12,11 @@ between two B |eacute| zier curves in :math:`\mathbf{R}^2`.
 Procedures
 **********
 
-.. c:function:: void bbox_intersect(int *num_nodes1, \
-                                    double *nodes1, \
-                                    int *num_nodes2, \
-                                    double *nodes2, \
-                                    BoxIntersectionType *enum_)
+.. c:function:: void BEZ_bbox_intersect(int *num_nodes1, \
+                                        double *nodes1, \
+                                        int *num_nodes2, \
+                                        double *nodes2, \
+                                        BoxIntersectionType *enum_)
 
    Determine how the bounding boxes of two B |eacute| zier curves intersect.
 
@@ -43,21 +43,21 @@ Procedures
    .. code-block:: c
 
       void
-      bbox_intersect(int *num_nodes1,
-                     double *nodes1,
-                     int *num_nodes2,
-                     double *nodes2,
-                     BoxIntersectionType *enum_);
+      BEZ_bbox_intersect(int *num_nodes1,
+                         double *nodes1,
+                         int *num_nodes2,
+                         double *nodes2,
+                         BoxIntersectionType *enum_);
 
-.. c:function:: void curve_intersections(int *num_nodes_first, \
-                                         double *nodes_first, \
-                                         int *num_nodes_second, \
-                                         double *nodes_second, \
-                                         int *intersections_size, \
-                                         double *intersections, \
-                                         int *num_intersections, \
-                                         bool *coincident, \
-                                         Status *status)
+.. c:function:: void BEZ_curve_intersections(int *num_nodes_first, \
+                                             double *nodes_first, \
+                                             int *num_nodes_second, \
+                                             double *nodes_second, \
+                                             int *intersections_size, \
+                                             double *intersections, \
+                                             int *num_intersections, \
+                                             bool *coincident, \
+                                             Status *status)
 
    Compute the intersection points of two B |eacute| zier curves in
    :math:`\mathbf{R}^2`. Does so by subdividing each curve in half and
@@ -133,25 +133,25 @@ Procedures
    .. code-block:: c
 
       void
-      curve_intersections(int *num_nodes_first,
-                          double *nodes_first,
-                          int *num_nodes_second,
-                          double *nodes_second,
-                          int *intersections_size,
-                          double *intersections,
-                          int *num_intersections,
-                          bool *coincident,
-                          Status *status);
+      BEZ_curve_intersections(int *num_nodes_first,
+                              double *nodes_first,
+                              int *num_nodes_second,
+                              double *nodes_second,
+                              int *intersections_size,
+                              double *intersections,
+                              int *num_intersections,
+                              bool *coincident,
+                              Status *status);
 
-.. c:function:: void newton_refine_curve_intersect(double *s, \
-                                                   int *num_nodes1, \
-                                                   double *nodes1, \
-                                                   double *t, \
-                                                   int *num_nodes2, \
-                                                   double *nodes2, \
-                                                   double *new_s, \
-                                                   double *new_t, \
-                                                   Status *status)
+.. c:function:: void BEZ_newton_refine_curve_intersect(double *s, \
+                                                       int *num_nodes1, \
+                                                       double *nodes1, \
+                                                       double *t, \
+                                                       int *num_nodes2, \
+                                                       double *nodes2, \
+                                                       double *new_s, \
+                                                       double *new_t, \
+                                                       Status *status)
 
    This refines a solution to :math:`F(s, t) = B_1(s) - B_2(t)` using Newton's
    method. Given a current approximation :math:`(s_n, t_n)` for a solution,
@@ -201,17 +201,17 @@ Procedures
    .. code-block:: c
 
       void
-      newton_refine_curve_intersect(double *s,
-                                    int *num_nodes1,
-                                    double *nodes1,
-                                    double *t,
-                                    int *num_nodes2,
-                                    double *nodes2,
-                                    double *new_s,
-                                    double *new_t,
-                                    Status *status);
+      BEZ_newton_refine_curve_intersect(double *s,
+                                        int *num_nodes1,
+                                        double *nodes1,
+                                        double *t,
+                                        int *num_nodes2,
+                                        double *nodes2,
+                                        double *new_s,
+                                        double *new_t,
+                                        Status *status);
 
-.. c:function:: void free_curve_intersections_workspace(void)
+.. c:function:: void BEZ_free_curve_intersections_workspace(void)
 
    This frees any long-lived workspace(s) used by ``libbezier`` throughout
    the life of a program. It should be called during clean-up for any code
@@ -222,7 +222,7 @@ Procedures
    .. code-block:: c
 
       void
-      free_curve_intersections_workspace(void);
+      BEZ_free_curve_intersections_workspace(void);
 
 *****
 Types

--- a/docs/abi/curve_intersection.rst
+++ b/docs/abi/curve_intersection.rst
@@ -215,7 +215,7 @@ Procedures
 
    This frees any long-lived workspace(s) used by ``libbezier`` throughout
    the life of a program. It should be called during clean-up for any code
-   which invokes :c:func:`curve_intersections`.
+   which invokes :c:func:`BEZ_curve_intersections`.
 
    **Signature:**
 

--- a/docs/abi/example_compute_length.c
+++ b/docs/abi/example_compute_length.c
@@ -24,7 +24,7 @@ int main(void)
     double length;
     int error_val;
 
-    compute_length(&num_nodes, &dimension, nodes, &length, &error_val);
+    BEZ_compute_length(&num_nodes, &dimension, nodes, &length, &error_val);
     printf("Length: %f\n", length);
     printf("Error value: %d\n", error_val);
 

--- a/docs/abi/example_elevate_nodes_curve.c
+++ b/docs/abi/example_elevate_nodes_curve.c
@@ -23,7 +23,7 @@ int main(void)
     // Outputs.
     double elevated[8];
 
-    elevate_nodes_curve(&num_nodes, &dimension, nodes, elevated);
+    BEZ_elevate_nodes_curve(&num_nodes, &dimension, nodes, elevated);
     printf("Elevated:\n");
     printf("%f, %f, %f, %f\n", elevated[0], elevated[2], elevated[4],
         elevated[6]);

--- a/docs/abi/example_evaluate_curve_barycentric.c
+++ b/docs/abi/example_evaluate_curve_barycentric.c
@@ -26,7 +26,7 @@ int main(void)
     // Outputs.
     double evaluated[8];
 
-    evaluate_curve_barycentric(
+    BEZ_evaluate_curve_barycentric(
         &num_nodes, &dimension, nodes, &num_vals, lambda1, lambda2, evaluated);
     printf("Evaluated:\n");
     printf("%f, %f, %f, %f\n", evaluated[0], evaluated[2], evaluated[4],

--- a/docs/abi/example_evaluate_hodograph.c
+++ b/docs/abi/example_evaluate_hodograph.c
@@ -24,7 +24,7 @@ int main(void)
     // Outputs.
     double hodograph[2];
 
-    evaluate_hodograph(&s, &num_nodes, &dimension, nodes, hodograph);
+    BEZ_evaluate_hodograph(&s, &num_nodes, &dimension, nodes, hodograph);
     printf("Hodograph:\n%f\n%f\n", hodograph[0], hodograph[1]);
 
     return 0;

--- a/docs/abi/example_evaluate_multi.c
+++ b/docs/abi/example_evaluate_multi.c
@@ -25,7 +25,7 @@ int main(void)
     // Outputs.
     double evaluated[6];
 
-    evaluate_multi(
+    BEZ_evaluate_multi(
         &num_nodes, &dimension, nodes, &num_vals, s_vals, evaluated);
     printf("Evaluated:\n");
     printf("%f, %f, %f\n", evaluated[0], evaluated[2], evaluated[4]);

--- a/docs/abi/example_full_reduce.c
+++ b/docs/abi/example_full_reduce.c
@@ -25,7 +25,7 @@ int main(void)
     double reduced[10];
     bool not_implemented;
 
-    full_reduce(&num_nodes, &dimension, nodes, &num_reduced_nodes, reduced,
+    BEZ_full_reduce(&num_nodes, &dimension, nodes, &num_reduced_nodes, reduced,
         &not_implemented);
     printf("Number of reduced nodes: %d\n", num_reduced_nodes);
     printf("Reduced:\n");

--- a/docs/abi/example_get_curvature.c
+++ b/docs/abi/example_get_curvature.c
@@ -24,7 +24,7 @@ int main(void)
     // Outputs.
     double curvature;
 
-    get_curvature(&num_nodes, nodes, tangent_vec, &s, &curvature);
+    BEZ_get_curvature(&num_nodes, nodes, tangent_vec, &s, &curvature);
     printf("Curvature: %f\n", curvature);
 
     return 0;

--- a/docs/abi/example_locate_point_curve.c
+++ b/docs/abi/example_locate_point_curve.c
@@ -28,9 +28,9 @@ int main(void)
 
     BEZ_locate_point_curve(&num_nodes, &dimension, nodes, point1, &s_approx);
     printf("When B(s) = [% f, %f]; s = % f\n", point1[0], point1[1], s_approx);
-    locate_point_curve(&num_nodes, &dimension, nodes, point2, &s_approx);
+    BEZ_locate_point_curve(&num_nodes, &dimension, nodes, point2, &s_approx);
     printf("When B(s) = [% f, %f]; s = % f\n", point2[0], point2[1], s_approx);
-    locate_point_curve(&num_nodes, &dimension, nodes, point3, &s_approx);
+    BEZ_locate_point_curve(&num_nodes, &dimension, nodes, point3, &s_approx);
     printf("When B(s) = [% f, %f]; s = % f\n", point3[0], point3[1], s_approx);
 
     return 0;

--- a/docs/abi/example_locate_point_curve.c
+++ b/docs/abi/example_locate_point_curve.c
@@ -26,7 +26,7 @@ int main(void)
     // Outputs.
     double s_approx;
 
-    locate_point_curve(&num_nodes, &dimension, nodes, point1, &s_approx);
+    BEZ_locate_point_curve(&num_nodes, &dimension, nodes, point1, &s_approx);
     printf("When B(s) = [% f, %f]; s = % f\n", point1[0], point1[1], s_approx);
     locate_point_curve(&num_nodes, &dimension, nodes, point2, &s_approx);
     printf("When B(s) = [% f, %f]; s = % f\n", point2[0], point2[1], s_approx);

--- a/docs/abi/example_newton_refine_curve.c
+++ b/docs/abi/example_newton_refine_curve.c
@@ -25,7 +25,8 @@ int main(void)
     // Outputs.
     double updated_s;
 
-    BEZ_newton_refine_curve(&num_nodes, &dimension, nodes, point, &s, &updated_s);
+    BEZ_newton_refine_curve(
+        &num_nodes, &dimension, nodes, point, &s, &updated_s);
     printf("Updated s: %f\n", updated_s);
 
     return 0;

--- a/docs/abi/example_newton_refine_curve.c
+++ b/docs/abi/example_newton_refine_curve.c
@@ -25,7 +25,7 @@ int main(void)
     // Outputs.
     double updated_s;
 
-    newton_refine_curve(&num_nodes, &dimension, nodes, point, &s, &updated_s);
+    BEZ_newton_refine_curve(&num_nodes, &dimension, nodes, point, &s, &updated_s);
     printf("Updated s: %f\n", updated_s);
 
     return 0;

--- a/docs/abi/example_reduce_pseudo_inverse.c
+++ b/docs/abi/example_reduce_pseudo_inverse.c
@@ -24,7 +24,7 @@ int main(void)
     double reduced[6];
     bool not_implemented;
 
-    reduce_pseudo_inverse(
+    BEZ_reduce_pseudo_inverse(
         &num_nodes, &dimension, nodes, reduced, &not_implemented);
     printf("Reduced:\n");
     printf("% f, %f, %f\n", reduced[0], reduced[2], reduced[4]);

--- a/docs/abi/example_specialize_curve.c
+++ b/docs/abi/example_specialize_curve.c
@@ -25,7 +25,7 @@ int main(void)
     // Outputs.
     double new_nodes[6];
 
-    specialize_curve(&num_nodes, &dimension, nodes, &start, &end, new_nodes);
+    BEZ_specialize_curve(&num_nodes, &dimension, nodes, &start, &end, new_nodes);
     printf("New Nodes:\n");
     printf("%f, %f, %f\n", new_nodes[0], new_nodes[2], new_nodes[4]);
     printf("%f, %f, %f\n", new_nodes[1], new_nodes[3], new_nodes[5]);

--- a/docs/abi/example_specialize_curve.c
+++ b/docs/abi/example_specialize_curve.c
@@ -25,7 +25,8 @@ int main(void)
     // Outputs.
     double new_nodes[6];
 
-    BEZ_specialize_curve(&num_nodes, &dimension, nodes, &start, &end, new_nodes);
+    BEZ_specialize_curve(
+        &num_nodes, &dimension, nodes, &start, &end, new_nodes);
     printf("New Nodes:\n");
     printf("%f, %f, %f\n", new_nodes[0], new_nodes[2], new_nodes[4]);
     printf("%f, %f, %f\n", new_nodes[1], new_nodes[3], new_nodes[5]);

--- a/docs/abi/example_status.c
+++ b/docs/abi/example_status.c
@@ -27,7 +27,7 @@ int main(void)
     double new_s, new_t;
     Status status;
 
-    newton_refine_curve_intersect(&s, &num_nodes1, nodes1, &t, &num_nodes2,
+    BEZ_newton_refine_curve_intersect(&s, &num_nodes1, nodes1, &t, &num_nodes2,
         nodes2, &new_s, &new_t, &status);
     if (status == SINGULAR) {
         printf("Jacobian is singular.\n");

--- a/docs/abi/example_subdivide_nodes_curve.c
+++ b/docs/abi/example_subdivide_nodes_curve.c
@@ -24,7 +24,7 @@ int main(void)
     double left_nodes[6];
     double right_nodes[6];
 
-    subdivide_nodes_curve(
+    BEZ_subdivide_nodes_curve(
         &num_nodes, &dimension, nodes, left_nodes, right_nodes);
     printf("Left Nodes:\n");
     printf("%f, %f, %f\n", left_nodes[0], left_nodes[2], left_nodes[4]);

--- a/docs/abi/helpers.rst
+++ b/docs/abi/helpers.rst
@@ -9,12 +9,12 @@ with various geometric computations.
 Procedures
 **********
 
-.. c:function:: void bbox(int *num_nodes, \
-                          double *nodes, \
-                          double *left, \
-                          double *right, \
-                          double *bottom, \
-                          double *top)
+.. c:function:: void BEZ_bbox(int *num_nodes, \
+                              double *nodes, \
+                              double *left, \
+                              double *right, \
+                              double *bottom, \
+                              double *top)
 
    Computes a rectangular bounding box
    :math:`\left[m_x, M_x\right] \times \left[m_y, M_y\right]`
@@ -39,18 +39,18 @@ Procedures
    .. code-block:: c
 
       void
-      bbox(int *num_nodes,
-           double *nodes,
-           double *left,
-           double *right,
-           double *bottom,
-           double *top);
+      BEZ_bbox(int *num_nodes,
+               double *nodes,
+               double *left,
+               double *right,
+               double *bottom,
+               double *top);
 
-.. c:function:: void contains_nd(int *num_nodes, \
-                                 int *dimension, \
-                                 double *nodes, \
-                                 double *point, \
-                                 bool *predicate)
+.. c:function:: void BEZ_contains_nd(int *num_nodes, \
+                                     int *dimension, \
+                                     double *nodes, \
+                                     double *point, \
+                                     bool *predicate)
 
    Checks if a point :math:`p` is contained in the bounding box
    for a set of points.
@@ -73,15 +73,15 @@ Procedures
    .. code-block:: c
 
       void
-      contains_nd(int *num_nodes,
-                  int *dimension,
-                  double *nodes,
-                  double *point,
-                  bool *predicate);
+      BEZ_contains_nd(int *num_nodes,
+                      int *dimension,
+                      double *nodes,
+                      double *point,
+                      bool *predicate);
 
-.. c:function:: void cross_product(double *vec0, \
-                                   double *vec1, \
-                                   double *result)
+.. c:function:: void BEZ_cross_product(double *vec0, \
+                                       double *vec1, \
+                                       double *result)
 
    Computes the cross-product of two vectors :math:`v_1, v_2` in
    :math:`\mathbf{R}^2`. This is done as if they were embedded in
@@ -100,13 +100,13 @@ Procedures
    .. code-block:: c
 
       void
-      cross_product(double *vec0,
-                    double *vec1,
-                    double *result);
+      BEZ_cross_product(double *vec0,
+                        double *vec1,
+                        double *result);
 
-.. c:function:: bool in_interval(double *value, \
-                                 double *start, \
-                                 double *end)
+.. c:function:: bool BEZ_in_interval(double *value, \
+                                     double *start, \
+                                     double *end)
 
    Checks if a value :math:`v` is in an interval :math:`\left[s, e\right]`.
 
@@ -125,15 +125,15 @@ Procedures
    .. code-block:: c
 
       bool
-      in_interval(double *value,
-                  double *start,
-                  double *end);
+      BEZ_in_interval(double *value,
+                     double *start,
+                     double *end);
 
-.. c:function:: void polygon_collide(int *polygon_size1, \
-                                     double *polygon1, \
-                                     int *polygon_size2, \
-                                     double *polygon2, \
-                                     bool *collision)
+.. c:function:: void BEZ_polygon_collide(int *polygon_size1, \
+                                         double *polygon1, \
+                                         int *polygon_size2, \
+                                         double *polygon2, \
+                                         bool *collision)
 
    Determines if two polygons collide.
 
@@ -155,16 +155,16 @@ Procedures
    .. code-block:: c
 
       void
-      polygon_collide(int *polygon_size1,
-                      double *polygon1,
-                      int *polygon_size2,
-                      double *polygon2,
-                      bool *collision);
+      BEZ_polygon_collide(int *polygon_size1,
+                          double *polygon1,
+                          int *polygon_size2,
+                          double *polygon2,
+                          bool *collision);
 
-.. c:function:: void simple_convex_hull(int *num_points, \
-                                        double *points, \
-                                        int *polygon_size, \
-                                        double *polygon)
+.. c:function:: void BEZ_simple_convex_hull(int *num_points, \
+                                            double *points, \
+                                            int *polygon_size, \
+                                            double *polygon)
 
    Computes the convex hull of a set of points.
 
@@ -186,15 +186,15 @@ Procedures
    .. code-block:: c
 
       void
-      simple_convex_hull(int *num_points,
-                         double *points,
-                         int *polygon_size,
-                         double *polygon);
+      BEZ_simple_convex_hull(int *num_points,
+                             double *points,
+                             int *polygon_size,
+                             double *polygon);
 
-.. c:function:: bool vector_close(int *num_values, \
-                                  double *vec1, \
-                                  double *vec2, \
-                                  double *eps)
+.. c:function:: bool BEZ_vector_close(int *num_values, \
+                                      double *vec1, \
+                                      double *vec2, \
+                                      double *eps)
 
    Determines if two vectors are close to machine precision.
 
@@ -222,14 +222,14 @@ Procedures
    .. code-block:: c
 
       bool
-      vector_close(int *num_values,
-                   double *vec1,
-                   double *vec2,
-                   double *eps);
+      BEZ_vector_close(int *num_values,
+                       double *vec1,
+                       double *vec2,
+                       double *eps);
 
-.. c:function:: void wiggle_interval(double *value, \
-                                     double *result, \
-                                     bool *success)
+.. c:function:: void BEZ_wiggle_interval(double *value, \
+                                         double *result, \
+                                         bool *success)
 
    Round a value :math:`v` into the unit interval if it is sufficiently
    close. The real line will be broken into five intervals and handled
@@ -260,6 +260,6 @@ Procedures
    .. code-block:: c
 
       void
-      wiggle_interval(double *value,
-                      double *result,
-                      bool *success);
+      BEZ_wiggle_interval(double *value,
+                          double *result,
+                          bool *success);

--- a/docs/abi/status.rst
+++ b/docs/abi/status.rst
@@ -113,7 +113,7 @@ status module
       $ gcc \
       >   -o example \
       >   example_status.c \
-      >   -I src/fortran/include/ \
+      >   -I .../src/fortran/include \
       >   -L .../site-packages/bezier/lib \
       >   -lbezier \
       >   -lm -lgfortran

--- a/docs/abi/surface.rst
+++ b/docs/abi/surface.rst
@@ -23,11 +23,11 @@ B |eacute| zier `surface`_.
 Procedures
 **********
 
-.. c:function:: void compute_area(int *num_edges, \
-                                  int *sizes, \
-                                  double **nodes_pointers, \
-                                  double *area, \
-                                  bool *not_implemented)
+.. c:function:: void BEZ_compute_area(int *num_edges, \
+                                      int *sizes, \
+                                      double **nodes_pointers, \
+                                      double *area, \
+                                      bool *not_implemented)
 
    This computes the area of a curved polygon in :math:`\mathbf{R}^2` via
    Green's theorem. In order to do this, it assumes that the edges
@@ -58,19 +58,19 @@ Procedures
    .. code-block:: c
 
       void
-      compute_area(int *num_edges,
-                   int *sizes,
-                   double **nodes_pointers,
-                   double *area,
-                   bool *not_implemented);
+      BEZ_compute_area(int *num_edges,
+                       int *sizes,
+                       double **nodes_pointers,
+                       double *area,
+                       bool *not_implemented);
 
-.. c:function:: void compute_edge_nodes(int *num_nodes, \
-                                        int *dimension, \
-                                        double *nodes, \
-                                        int *degree, \
-                                        double *nodes1, \
-                                        double *nodes2, \
-                                        double *nodes3)
+.. c:function:: void BEZ_compute_edge_nodes(int *num_nodes, \
+                                            int *dimension, \
+                                            double *nodes, \
+                                            int *degree, \
+                                            double *nodes1, \
+                                            double *nodes2, \
+                                            double *nodes3)
 
    Extracts the edge nodes from the control net of a B |eacute| zier surface.
    For example, if the control net of a quadratic surface is:
@@ -124,22 +124,22 @@ Procedures
    .. code-block:: c
 
       void
-      compute_edge_nodes(int *num_nodes,
-                         int *dimension,
-                         double *nodes,
-                         int *degree,
-                         double *nodes1,
-                         double *nodes2,
-                         double *nodes3);
+      BEZ_compute_edge_nodes(int *num_nodes,
+                             int *dimension,
+                             double *nodes,
+                             int *degree,
+                             double *nodes1,
+                             double *nodes2,
+                             double *nodes3);
 
-.. c:function:: void de_casteljau_one_round(int *num_nodes, \
-                                            int *dimension, \
-                                            double *nodes, \
-                                            int *degree, \
-                                            double *lambda1, \
-                                            double *lambda2, \
-                                            double *lambda3, \
-                                            double *new_nodes)
+.. c:function:: void BEZ_de_casteljau_one_round(int *num_nodes, \
+                                                int *dimension, \
+                                                double *nodes, \
+                                                int *degree, \
+                                                double *lambda1, \
+                                                double *lambda2, \
+                                                double *lambda3, \
+                                                double *new_nodes)
 
    This performs a single round of the de Casteljau algorithm for evaluation
    in barycentric coordinates :math:`B(\lambda_1, \lambda_2, \lambda_3)`. This
@@ -178,23 +178,23 @@ Procedures
    .. code-block:: c
 
       void
-      de_casteljau_one_round(int *num_nodes,
-                             int *dimension,
-                             double *nodes,
-                             int *degree,
-                             double *lambda1,
-                             double *lambda2,
-                             double *lambda3,
-                             double *new_nodes);
+      BEZ_de_casteljau_one_round(int *num_nodes,
+                                 int *dimension,
+                                 double *nodes,
+                                 int *degree,
+                                 double *lambda1,
+                                 double *lambda2,
+                                 double *lambda3,
+                                 double *new_nodes);
 
-.. c:function:: void evaluate_barycentric(int *num_nodes, \
-                                          int *dimension, \
-                                          double *nodes, \
-                                          int *degree, \
-                                          double *lambda1, \
-                                          double *lambda2, \
-                                          double *lambda3, \
-                                          double *point)
+.. c:function:: void BEZ_evaluate_barycentric(int *num_nodes, \
+                                              int *dimension, \
+                                              double *nodes, \
+                                              int *degree, \
+                                              double *lambda1, \
+                                              double *lambda2, \
+                                              double *lambda3, \
+                                              double *point)
 
    Evaluates a single point on a B |eacute| zier surface, with input
    in barycentric coordinates: :math:`B(\lambda_1, \lambda_2, \lambda_3)`.
@@ -227,22 +227,22 @@ Procedures
    .. code-block:: c
 
       void
-      evaluate_barycentric(int *num_nodes,
-                           int *dimension,
-                           double *nodes,
-                           int *degree,
-                           double *lambda1,
-                           double *lambda2,
-                           double *lambda3,
-                           double *point);
+      BEZ_evaluate_barycentric(int *num_nodes,
+                               int *dimension,
+                               double *nodes,
+                               int *degree,
+                               double *lambda1,
+                               double *lambda2,
+                               double *lambda3,
+                               double *point);
 
-.. c:function:: void evaluate_barycentric_multi(int *num_nodes, \
-                                                int *dimension, \
-                                                double *nodes, \
-                                                int *degree, \
-                                                int *num_vals, \
-                                                double *param_vals, \
-                                                double *evaluated)
+.. c:function:: void BEZ_evaluate_barycentric_multi(int *num_nodes, \
+                                                    int *dimension, \
+                                                    double *nodes, \
+                                                    int *degree, \
+                                                    int *num_vals, \
+                                                    double *param_vals, \
+                                                    double *evaluated)
 
    Evaluates many points on a B |eacute| zier surface, with input
    in barycentric coordinates:
@@ -278,21 +278,21 @@ Procedures
    .. code-block:: c
 
       void
-      evaluate_barycentric_multi(int *num_nodes,
-                                 int *dimension,
-                                 double *nodes,
-                                 int *degree,
-                                 int *num_vals,
-                                 double *param_vals,
-                                 double *evaluated);
+      BEZ_evaluate_barycentric_multi(int *num_nodes,
+                                     int *dimension,
+                                     double *nodes,
+                                     int *degree,
+                                     int *num_vals,
+                                     double *param_vals,
+                                     double *evaluated);
 
-.. c:function:: void evaluate_cartesian_multi(int *num_nodes, \
-                                              int *dimension, \
-                                              double *nodes, \
-                                              int *degree, \
-                                              int *num_vals, \
-                                              double *param_vals, \
-                                              double *evaluated)
+.. c:function:: void BEZ_evaluate_cartesian_multi(int *num_nodes, \
+                                                  int *dimension, \
+                                                  double *nodes, \
+                                                  int *degree, \
+                                                  int *num_vals, \
+                                                  double *param_vals, \
+                                                  double *evaluated)
 
    Evaluates many points on a B |eacute| zier surface, with input
    in cartesian coordinates:
@@ -330,19 +330,19 @@ Procedures
    .. code-block:: c
 
       void
-      evaluate_cartesian_multi(int *num_nodes,
-                               int *dimension,
-                               double *nodes,
-                               int *degree,
-                               int *num_vals,
-                               double *param_vals,
-                               double *evaluated);
+      BEZ_evaluate_cartesian_multi(int *num_nodes,
+                                   int *dimension,
+                                   double *nodes,
+                                   int *degree,
+                                   int *num_vals,
+                                   double *param_vals,
+                                   double *evaluated);
 
-.. c:function:: void jacobian_both(int *num_nodes, \
-                                   int *dimension, \
-                                   double *nodes, \
-                                   int *degree, \
-                                   double *new_nodes)
+.. c:function:: void BEZ_jacobian_both(int *num_nodes, \
+                                       int *dimension, \
+                                       double *nodes, \
+                                       int *degree, \
+                                       double *new_nodes)
 
    Computes control nets for both cartesian partial derivatives of a
    B |eacute| zier surface :math:`B_s(s, t)` and :math:`B_t(s, t)`. Taking
@@ -371,18 +371,18 @@ Procedures
    .. code-block:: c
 
       void
-      jacobian_both(int *num_nodes,
-                    int *dimension,
-                    double *nodes,
-                    int *degree,
-                    double *new_nodes);
+      BEZ_jacobian_both(int *num_nodes,
+                        int *dimension,
+                        double *nodes,
+                        int *degree,
+                        double *new_nodes);
 
-.. c:function:: void jacobian_det(int *num_nodes, \
-                                  double *nodes, \
-                                  int *degree, \
-                                  int *num_vals, \
-                                  double *param_vals, \
-                                  double *evaluated)
+.. c:function:: void BEZ_jacobian_det(int *num_nodes, \
+                                      double *nodes, \
+                                      int *degree, \
+                                      int *num_vals, \
+                                      double *param_vals, \
+                                      double *evaluated)
 
    Computes :math:`\det(DB)` at many points :math:`(s_j, t_j)`. This is only
    well-defined if :math:`\det(DB)` has two rows, hence the surface must lie
@@ -414,21 +414,21 @@ Procedures
    .. code-block:: c
 
       void
-      jacobian_det(int *num_nodes,
-                   double *nodes,
-                   int *degree,
-                   int *num_vals,
-                   double *param_vals,
-                   double *evaluated);
+      BEZ_jacobian_det(int *num_nodes,
+                       double *nodes,
+                       int *degree,
+                       int *num_vals,
+                       double *param_vals,
+                       double *evaluated);
 
-.. c:function:: void specialize_surface(int *num_nodes, \
-                                        int *dimension, \
-                                        double *nodes, \
-                                        int *degree, \
-                                        double *weights_a, \
-                                        double *weights_b, \
-                                        double *weights_c, \
-                                        double *specialized)
+.. c:function:: void BEZ_specialize_surface(int *num_nodes, \
+                                            int *dimension, \
+                                            double *nodes, \
+                                            int *degree, \
+                                            double *weights_a, \
+                                            double *weights_b, \
+                                            double *weights_c, \
+                                            double *specialized)
 
    Changes the control net for a B |eacute| zier surface by specializing
    from the original triangle :math:`(0, 0), (1, 0), (0, 1)` to a new
@@ -464,23 +464,23 @@ Procedures
    .. code-block:: c
 
       void
-      specialize_surface(int *num_nodes,
-                         int *dimension,
-                         double *nodes,
-                         int *degree,
-                         double *weights_a,
-                         double *weights_b,
-                         double *weights_c,
-                         double *specialized);
+      BEZ_specialize_surface(int *num_nodes,
+                             int *dimension,
+                             double *nodes,
+                             int *degree,
+                             double *weights_a,
+                             double *weights_b,
+                             double *weights_c,
+                             double *specialized);
 
-.. c:function:: void subdivide_nodes_surface(int *num_nodes, \
-                                             int *dimension, \
-                                             double *nodes, \
-                                             int *degree, \
-                                             double *nodes_a, \
-                                             double *nodes_b, \
-                                             double *nodes_c, \
-                                             double *nodes_d)
+.. c:function:: void BEZ_subdivide_nodes_surface(int *num_nodes, \
+                                                 int *dimension, \
+                                                 double *nodes, \
+                                                 int *degree, \
+                                                 double *nodes_a, \
+                                                 double *nodes_b, \
+                                                 double *nodes_c, \
+                                                 double *nodes_d)
 
    Subdivides a B |eacute| zier surface into four sub-surfaces that cover
    the original surface. See :meth:`.Surface.subdivide` for more
@@ -516,11 +516,11 @@ Procedures
    .. code-block:: c
 
       void
-      subdivide_nodes_surface(int *num_nodes,
-                              int *dimension,
-                              double *nodes,
-                              int *degree,
-                              double *nodes_a,
-                              double *nodes_b,
-                              double *nodes_c,
-                              double *nodes_d);
+      BEZ_subdivide_nodes_surface(int *num_nodes,
+                                  int *dimension,
+                                  double *nodes,
+                                  int *degree,
+                                  double *nodes_a,
+                                  double *nodes_b,
+                                  double *nodes_c,
+                                  double *nodes_d);

--- a/docs/abi/surface_intersection.rst
+++ b/docs/abi/surface_intersection.rst
@@ -23,13 +23,13 @@ the B |eacute| zier curve segments that form the exterior.
 Procedures
 **********
 
-.. c:function:: void locate_point_surface(int *num_nodes, \
-                                          double *nodes, \
-                                          int *degree, \
-                                          double *x_val, \
-                                          double *y_val, \
-                                          double *s_val, \
-                                          double *t_val)
+.. c:function:: void BEZ_locate_point_surface(int *num_nodes, \
+                                              double *nodes, \
+                                              int *degree, \
+                                              double *x_val, \
+                                              double *y_val, \
+                                              double *s_val, \
+                                              double *t_val)
 
    This solves the inverse problem :math:`B(s, t) = (x, y)` (if it can be
    solved). Does so by subdividing the surface until the sub-surfaces are
@@ -66,23 +66,23 @@ Procedures
    .. code-block:: c
 
       void
-      locate_point_surface(int *num_nodes,
-                           double *nodes,
-                           int *degree,
-                           double *x_val,
-                           double *y_val,
-                           double *s_val,
-                           double *t_val);
+      BEZ_locate_point_surface(int *num_nodes,
+                               double *nodes,
+                               int *degree,
+                               double *x_val,
+                               double *y_val,
+                               double *s_val,
+                               double *t_val);
 
-.. c:function:: void newton_refine_surface(int *num_nodes, \
-                                           double *nodes, \
-                                           int *degree, \
-                                           double *x_val, \
-                                           double *y_val, \
-                                           double *s, \
-                                           double *t, \
-                                           double *updated_s, \
-                                           double *updated_t)
+.. c:function:: void BEZ_newton_refine_surface(int *num_nodes, \
+                                               double *nodes, \
+                                               int *degree, \
+                                               double *x_val, \
+                                               double *y_val, \
+                                               double *s, \
+                                               double *t, \
+                                               double *updated_s, \
+                                               double *updated_t)
 
    This refines a solution to :math:`B(s, t) = (x, y) = p` using Newton's
    method. Given a current approximation :math:`(s_n, t_n)` for a solution,
@@ -125,29 +125,29 @@ Procedures
    .. code-block:: c
 
       void
-      newton_refine_surface(int *num_nodes,
-                            double *nodes,
-                            int *degree,
-                            double *x_val,
-                            double *y_val,
-                            double *s,
-                            double *t,
-                            double *updated_s,
-                            double *updated_t);
+      BEZ_newton_refine_surface(int *num_nodes,
+                                double *nodes,
+                                int *degree,
+                                double *x_val,
+                                double *y_val,
+                                double *s,
+                                double *t,
+                                double *updated_s,
+                                double *updated_t);
 
-.. c:function:: void surface_intersections(int *num_nodes1, \
-                                           double *nodes1, \
-                                           int *degree1, \
-                                           int *num_nodes2, \
-                                           double *nodes2, \
-                                           int *degree2, \
-                                           int *segment_ends_size, \
-                                           int *segment_ends, \
-                                           int *segments_size, \
-                                           CurvedPolygonSegment *segments, \
-                                           int *num_intersected, \
-                                           SurfaceContained *contained, \
-                                           Status *status)
+.. c:function:: void BEZ_surface_intersections(int *num_nodes1, \
+                                               double *nodes1, \
+                                               int *degree1, \
+                                               int *num_nodes2, \
+                                               double *nodes2, \
+                                               int *degree2, \
+                                               int *segment_ends_size, \
+                                               int *segment_ends, \
+                                               int *segments_size, \
+                                               CurvedPolygonSegment *segments, \
+                                               int *num_intersected, \
+                                               SurfaceContained *contained, \
+                                               Status *status)
 
    Compute the intersection of two B |eacute| zier surfaces. This will
    first compute all intersection points between edges of the first and
@@ -257,21 +257,21 @@ Procedures
    .. code-block:: c
 
       void
-      surface_intersections(int *num_nodes1,
-                            double *nodes1,
-                            int *degree1,
-                            int *num_nodes2,
-                            double *nodes2,
-                            int *degree2,
-                            int *segment_ends_size,
-                            int *segment_ends,
-                            int *segments_size,
-                            CurvedPolygonSegment *segments,
-                            int *num_intersected,
-                            SurfaceContained *contained,
-                            Status *status);
+      BEZ_surface_intersections(int *num_nodes1,
+                                double *nodes1,
+                                int *degree1,
+                                int *num_nodes2,
+                                double *nodes2,
+                                int *degree2,
+                                int *segment_ends_size,
+                                int *segment_ends,
+                                int *segments_size,
+                                CurvedPolygonSegment *segments,
+                                int *num_intersected,
+                                SurfaceContained *contained,
+                                Status *status);
 
-.. c:function:: void free_surface_intersections_workspace(void)
+.. c:function:: void BEZ_free_surface_intersections_workspace(void)
 
    This frees any long-lived workspace(s) used by ``libbezier`` throughout
    the life of a program. It should be called during clean-up for any code
@@ -282,7 +282,7 @@ Procedures
    .. code-block:: c
 
       void
-      free_surface_intersections_workspace(void);
+      BEZ_free_surface_intersections_workspace(void);
 
 *****
 Types

--- a/docs/abi/surface_intersection.rst
+++ b/docs/abi/surface_intersection.rst
@@ -227,17 +227,17 @@ Procedures
         intersection, but no other types).
       * :c:data:`NO_CONVERGE` if the two curves in an edge pair don't converge
         to approximately linear after being subdivided 20 times. (This error
-        will occur via :c:func:`curve_intersections`.)
+        will occur via :c:func:`BEZ_curve_intersections`.)
       * An integer :math:`N_C \geq 64` to indicate that there were :math:`N_C`
         pairs of candidate segments during edge-edge intersection that had
         overlapping convex hulls. This is a sign of either round-off error
         in detecting that the edges are coincident curve segments on the same
         algebraic curve or that the intersection is a non-simple root. (This
-        error will occur via :c:func:`curve_intersections`.)
+        error will occur via :c:func:`BEZ_curve_intersections`.)
       * :c:data:`BAD_MULTIPLICITY` if the two curves in an edge pair have an
         intersection that doesn't converge to either a simple or double root
         via Newton's method. (This error will occur via
-        :c:func:`curve_intersections`.)
+        :c:func:`BEZ_curve_intersections`.)
       * :c:data:`EDGE_END` If there is an attempt to add an intersection
         point with either the :math:`s` or :math:`t`\-parameter equal to 1
         (i.e. if the intersection is at the end of an edge). This should
@@ -275,7 +275,7 @@ Procedures
 
    This frees any long-lived workspace(s) used by ``libbezier`` throughout
    the life of a program. It should be called during clean-up for any code
-   which invokes :c:func:`surface_intersections`.
+   which invokes :c:func:`BEZ_surface_intersections`.
 
    **Signature:**
 

--- a/docs/releases/latest.rst
+++ b/docs/releases/latest.rst
@@ -64,6 +64,16 @@ Miscellany
 -  Moved ``*.f90`` Fortran files **out** of Python source tree
    (`#152 <https://github.com/dhermes/bezier/pull/152>`__).
 
+ABI Changes
+-----------
+
+Breaking Changes
+~~~~~~~~~~~~~~~~
+
+-  Added `BEZ_` prefix for exported ABI names
+   (`#167 <https://github.com/dhermes/bezier/pull/167>`__).
+   Fixed `#166 <https://github.com/dhermes/bezier/issues/166>`__.
+
 Bug Fixes
 ---------
 

--- a/src/fortran/curve.f90
+++ b/src/fortran/curve.f90
@@ -97,7 +97,7 @@ contains
 
   subroutine evaluate_curve_barycentric( &
        num_nodes, dimension_, nodes, num_vals, lambda1, lambda2, evaluated) &
-       bind(c, name='evaluate_curve_barycentric')
+       bind(c, name='BEZ_evaluate_curve_barycentric')
 
     ! NOTE: This is evaluate_multi_barycentric for a Bezier curve.
 
@@ -139,7 +139,7 @@ contains
 
   subroutine evaluate_multi( &
        num_nodes, dimension_, nodes, num_vals, s_vals, evaluated) &
-       bind(c, name='evaluate_multi')
+       bind(c, name='BEZ_evaluate_multi')
 
     ! NOTE: This is evaluate_multi for a Bezier curve.
 
@@ -233,7 +233,7 @@ contains
 
   subroutine specialize_curve( &
        num_nodes, dimension_, nodes, start, end_, new_nodes) &
-       bind(c, name='specialize_curve')
+       bind(c, name='BEZ_specialize_curve')
 
     integer(c_int), intent(in) :: num_nodes, dimension_
     real(c_double), intent(in) :: nodes(dimension_, num_nodes)
@@ -255,7 +255,7 @@ contains
 
   subroutine evaluate_hodograph( &
        s, num_nodes, dimension_, nodes, hodograph) &
-       bind(c, name='evaluate_hodograph')
+       bind(c, name='BEZ_evaluate_hodograph')
 
     real(c_double), intent(in) :: s
     integer(c_int), intent(in) :: num_nodes, dimension_
@@ -309,7 +309,7 @@ contains
 
   subroutine subdivide_nodes( &
        num_nodes, dimension_, nodes, left_nodes, right_nodes) &
-       bind(c, name='subdivide_nodes_curve')
+       bind(c, name='BEZ_subdivide_nodes_curve')
 
     integer(c_int), intent(in) :: num_nodes, dimension_
     real(c_double), intent(in) :: nodes(dimension_, num_nodes)
@@ -350,7 +350,7 @@ contains
 
   subroutine newton_refine( &
        num_nodes, dimension_, nodes, point, s, updated_s) &
-       bind(c, name='newton_refine_curve')
+       bind(c, name='BEZ_newton_refine_curve')
 
     integer(c_int), intent(in) :: num_nodes, dimension_
     real(c_double), intent(in) :: nodes(dimension_, num_nodes)
@@ -457,7 +457,7 @@ contains
 
   subroutine locate_point( &
        num_nodes, dimension_, nodes, point, s_approx) &
-       bind(c, name='locate_point_curve')
+       bind(c, name='BEZ_locate_point_curve')
 
     ! NOTE: This returns ``-1`` (``LOCATE_MISS``) as a signal for "point is
     !       not on the curve" and ``-2`` (``LOCATE_INVALID``) for "point is
@@ -552,7 +552,7 @@ contains
 
   subroutine elevate_nodes( &
        num_nodes, dimension_, nodes, elevated) &
-       bind(c, name='elevate_nodes_curve')
+       bind(c, name='BEZ_elevate_nodes_curve')
 
     integer(c_int), intent(in) :: num_nodes, dimension_
     real(c_double), intent(in) :: nodes(dimension_, num_nodes)
@@ -571,7 +571,7 @@ contains
 
   subroutine get_curvature( &
        num_nodes, nodes, tangent_vec, s, curvature) &
-       bind(c, name='get_curvature')
+       bind(c, name='BEZ_get_curvature')
 
     ! NOTE: This **only** computes curvature for plane curves (i.e. curves
     !       in R^2). An equivalent notion of curvature exists for space
@@ -611,7 +611,7 @@ contains
 
   subroutine reduce_pseudo_inverse( &
        num_nodes, dimension_, nodes, reduced, not_implemented) &
-       bind(c, name='reduce_pseudo_inverse')
+       bind(c, name='BEZ_reduce_pseudo_inverse')
 
     integer(c_int), intent(in) :: num_nodes, dimension_
     real(c_double), intent(in) :: nodes(dimension_, num_nodes)
@@ -746,7 +746,7 @@ contains
   subroutine full_reduce( &
        num_nodes, dimension_, nodes, num_reduced_nodes, &
        reduced, not_implemented) &
-       bind(c, name='full_reduce')
+       bind(c, name='BEZ_full_reduce')
 
     ! NOTE: The size of ``reduced`` represents the **maximum** possible
     !       size, but ``num_reduced_nodes`` actually reflects the number
@@ -796,7 +796,7 @@ contains
 
   subroutine compute_length( &
        num_nodes, dimension_, nodes, length, error_val) &
-       bind(c, name='compute_length')
+       bind(c, name='BEZ_compute_length')
 
     integer(c_int), intent(in) :: num_nodes, dimension_
     real(c_double), intent(in) :: nodes(dimension_, num_nodes)

--- a/src/fortran/curve_intersection.f90
+++ b/src/fortran/curve_intersection.f90
@@ -151,7 +151,7 @@ contains
 
   subroutine newton_refine_intersect( &
        s, num_nodes1, nodes1, t, num_nodes2, nodes2, new_s, new_t, status) &
-       bind(c, name='newton_refine_curve_intersect')
+       bind(c, name='BEZ_newton_refine_curve_intersect')
 
     ! Possible error states:
     ! * Status_SUCCESS : On success.
@@ -202,7 +202,7 @@ contains
 
   subroutine bbox_intersect( &
        num_nodes1, nodes1, num_nodes2, nodes2, enum_) &
-       bind(c, name='bbox_intersect')
+       bind(c, name='BEZ_bbox_intersect')
 
     integer(c_int), intent(in) :: num_nodes1
     real(c_double), intent(in) :: nodes1(2, num_nodes1)
@@ -1882,7 +1882,7 @@ contains
        num_nodes_first, nodes_first, num_nodes_second, nodes_second, &
        intersections_size, intersections, num_intersections, &
        coincident, status) &
-       bind(c, name='curve_intersections')
+       bind(c, name='BEZ_curve_intersections')
 
     ! NOTE: The number of intersections cannot be known beforehand (though it
     !       will be **at most** the product of the degrees of the two curves,
@@ -1932,7 +1932,7 @@ contains
   end subroutine all_intersections_abi
 
   subroutine free_curve_intersections_workspace() &
-       bind(c, name='free_curve_intersections_workspace')
+       bind(c, name='BEZ_free_curve_intersections_workspace')
 
     ! NOTE: This **should** be run during clean-up for any code which
     !       invokes ``all_intersections()``.

--- a/src/fortran/helpers.f90
+++ b/src/fortran/helpers.f90
@@ -30,7 +30,7 @@ contains
 
   pure subroutine cross_product( &
        vec0, vec1, result_) &
-       bind(c, name='cross_product')
+       bind(c, name='BEZ_cross_product')
 
     real(c_double), intent(in) :: vec0(2)
     real(c_double), intent(in) :: vec1(2)
@@ -42,7 +42,7 @@ contains
 
   subroutine bbox( &
        num_nodes, nodes, left, right, bottom, top) &
-       bind(c, name='bbox')
+       bind(c, name='BEZ_bbox')
 
     integer(c_int), intent(in) :: num_nodes
     real(c_double), intent(in) :: nodes(2, num_nodes)
@@ -61,7 +61,7 @@ contains
 
   subroutine wiggle_interval( &
        value_, result_, success) &
-       bind(c, name='wiggle_interval')
+       bind(c, name='BEZ_wiggle_interval')
 
     real(c_double), intent(in) :: value_
     real(c_double), intent(out) :: result_
@@ -83,7 +83,7 @@ contains
 
   pure subroutine contains_nd( &
        num_nodes, dimension_, nodes, point, predicate) &
-       bind(c, name='contains_nd')
+       bind(c, name='BEZ_contains_nd')
 
     integer(c_int), intent(in) :: num_nodes, dimension_
     real(c_double), intent(in) :: nodes(dimension_, num_nodes)
@@ -102,7 +102,7 @@ contains
 
   logical(c_bool) pure function vector_close( &
        num_values, vec1, vec2, eps) result(is_close) &
-       bind(c, name='vector_close')
+       bind(c, name='BEZ_vector_close')
 
     integer(c_int), intent(in) :: num_values
     real(c_double), intent(in) :: vec1(num_values)
@@ -126,7 +126,7 @@ contains
 
   pure function in_interval( &
        value_, start, end) result(predicate) &
-       bind(c, name='in_interval')
+       bind(c, name='BEZ_in_interval')
 
     real(c_double), intent(in) :: value_, start, end
     logical(c_bool) :: predicate
@@ -242,7 +242,7 @@ contains
 
   subroutine convex_hull( &
        num_points, points, polygon_size, polygon) &
-       bind(c, name='simple_convex_hull')
+       bind(c, name='BEZ_simple_convex_hull')
 
     ! NOTE: This uses Andrew's monotone chain convex hull algorithm and used
     !       (https://en.wikibooks.org/wiki/Algorithm_Implementation/
@@ -396,7 +396,7 @@ contains
 
   subroutine polygon_collide( &
        polygon_size1, polygon1, polygon_size2, polygon2, collision) &
-       bind(c, name='polygon_collide')
+       bind(c, name='BEZ_polygon_collide')
 
     ! This determines if two **convex** polygons collide. The polygons
     ! are given as ``2 x N`` arrays of ``x-y`` points (one per column)

--- a/src/fortran/include/bezier/curve.h
+++ b/src/fortran/include/bezier/curve.h
@@ -19,8 +19,9 @@
 extern "C" {
 #endif
 
-void BEZ_evaluate_curve_barycentric(int* num_nodes, int* dimension, double* nodes,
-    int* num_vals, double* lambda1, double* lambda2, double* evaluated);
+void BEZ_evaluate_curve_barycentric(int* num_nodes, int* dimension,
+    double* nodes, int* num_vals, double* lambda1, double* lambda2,
+    double* evaluated);
 void BEZ_evaluate_multi(int* num_nodes, int* dimension, double* nodes,
     int* num_vals, double* s_vals, double* evaluated);
 void BEZ_specialize_curve(int* num_nodes, int* dimension, double* nodes,

--- a/src/fortran/include/bezier/curve.h
+++ b/src/fortran/include/bezier/curve.h
@@ -19,29 +19,29 @@
 extern "C" {
 #endif
 
-void evaluate_curve_barycentric(int* num_nodes, int* dimension, double* nodes,
+void BEZ_evaluate_curve_barycentric(int* num_nodes, int* dimension, double* nodes,
     int* num_vals, double* lambda1, double* lambda2, double* evaluated);
-void evaluate_multi(int* num_nodes, int* dimension, double* nodes,
+void BEZ_evaluate_multi(int* num_nodes, int* dimension, double* nodes,
     int* num_vals, double* s_vals, double* evaluated);
-void specialize_curve(int* num_nodes, int* dimension, double* nodes,
+void BEZ_specialize_curve(int* num_nodes, int* dimension, double* nodes,
     double* start, double* end, double* new_nodes);
-void evaluate_hodograph(double* s, int* num_nodes, int* dimension,
+void BEZ_evaluate_hodograph(double* s, int* num_nodes, int* dimension,
     double* nodes, double* hodograph);
-void subdivide_nodes_curve(int* num_nodes, int* dimension, double* nodes,
+void BEZ_subdivide_nodes_curve(int* num_nodes, int* dimension, double* nodes,
     double* left_nodes, double* right_nodes);
-void newton_refine_curve(int* num_nodes, int* dimension, double* nodes,
+void BEZ_newton_refine_curve(int* num_nodes, int* dimension, double* nodes,
     double* point, double* s, double* updated_s);
-void locate_point_curve(int* num_nodes, int* dimension, double* nodes,
+void BEZ_locate_point_curve(int* num_nodes, int* dimension, double* nodes,
     double* point, double* s_approx);
-void elevate_nodes_curve(
+void BEZ_elevate_nodes_curve(
     int* num_nodes, int* dimension, double* nodes, double* elevated);
-void get_curvature(int* num_nodes, double* nodes, double* tangent_vec,
+void BEZ_get_curvature(int* num_nodes, double* nodes, double* tangent_vec,
     double* s, double* curvature);
-void reduce_pseudo_inverse(int* num_nodes, int* dimension, double* nodes,
+void BEZ_reduce_pseudo_inverse(int* num_nodes, int* dimension, double* nodes,
     double* reduced, bool* not_implemented);
-void full_reduce(int* num_nodes, int* dimension, double* nodes,
+void BEZ_full_reduce(int* num_nodes, int* dimension, double* nodes,
     int* num_reduced_nodes, double* reduced, bool* not_implemented);
-void compute_length(int* num_nodes, int* dimension, double* nodes,
+void BEZ_compute_length(int* num_nodes, int* dimension, double* nodes,
     double* length, int* error_val);
 
 #if defined(__cplusplus)

--- a/src/fortran/include/bezier/curve_intersection.h
+++ b/src/fortran/include/bezier/curve_intersection.h
@@ -26,9 +26,9 @@ typedef enum BoxIntersectionType {
     DISJOINT = 2,
 } BoxIntersectionType;
 
-void BEZ_newton_refine_curve_intersect(double* s, int* num_nodes1, double* nodes1,
-    double* t, int* num_nodes2, double* nodes2, double* new_s, double* new_t,
-    Status* status);
+void BEZ_newton_refine_curve_intersect(double* s, int* num_nodes1,
+    double* nodes1, double* t, int* num_nodes2, double* nodes2, double* new_s,
+    double* new_t, Status* status);
 void BEZ_bbox_intersect(int* num_nodes1, double* nodes1, int* num_nodes2,
     double* nodes2, BoxIntersectionType* enum_);
 void BEZ_curve_intersections(int* num_nodes_first, double* nodes_first,

--- a/src/fortran/include/bezier/curve_intersection.h
+++ b/src/fortran/include/bezier/curve_intersection.h
@@ -26,16 +26,16 @@ typedef enum BoxIntersectionType {
     DISJOINT = 2,
 } BoxIntersectionType;
 
-void newton_refine_curve_intersect(double* s, int* num_nodes1, double* nodes1,
+void BEZ_newton_refine_curve_intersect(double* s, int* num_nodes1, double* nodes1,
     double* t, int* num_nodes2, double* nodes2, double* new_s, double* new_t,
     Status* status);
-void bbox_intersect(int* num_nodes1, double* nodes1, int* num_nodes2,
+void BEZ_bbox_intersect(int* num_nodes1, double* nodes1, int* num_nodes2,
     double* nodes2, BoxIntersectionType* enum_);
-void curve_intersections(int* num_nodes_first, double* nodes_first,
+void BEZ_curve_intersections(int* num_nodes_first, double* nodes_first,
     int* num_nodes_second, double* nodes_second, int* intersections_size,
     double* intersections, int* num_intersections, bool* coincident,
     Status* status);
-void free_curve_intersections_workspace(void);
+void BEZ_free_curve_intersections_workspace(void);
 
 #if defined(__cplusplus)
 }

--- a/src/fortran/include/bezier/helpers.h
+++ b/src/fortran/include/bezier/helpers.h
@@ -23,14 +23,15 @@ void BEZ_cross_product(double* vec0, double* vec1, double* result);
 void BEZ_bbox(int* num_nodes, double* nodes, double* left, double* right,
     double* bottom, double* top);
 void BEZ_wiggle_interval(double* value, double* result, bool* success);
-void BEZ_contains_nd(int* num_nodes, int* dimension, double* nodes, double* point,
-    bool* predicate);
-bool BEZ_vector_close(int* num_values, double* vec1, double* vec2, double* eps);
+void BEZ_contains_nd(int* num_nodes, int* dimension, double* nodes,
+    double* point, bool* predicate);
+bool BEZ_vector_close(
+    int* num_values, double* vec1, double* vec2, double* eps);
 bool BEZ_in_interval(double* value, double* start, double* end);
 void BEZ_simple_convex_hull(
     int* num_points, double* points, int* polygon_size, double* polygon);
-void BEZ_polygon_collide(int* polygon_size1, double* polygon1, int* polygon_size2,
-    double* polygon2, bool* collision);
+void BEZ_polygon_collide(int* polygon_size1, double* polygon1,
+    int* polygon_size2, double* polygon2, bool* collision);
 
 #if defined(__cplusplus)
 }

--- a/src/fortran/include/bezier/helpers.h
+++ b/src/fortran/include/bezier/helpers.h
@@ -19,17 +19,17 @@
 extern "C" {
 #endif
 
-void cross_product(double* vec0, double* vec1, double* result);
-void bbox(int* num_nodes, double* nodes, double* left, double* right,
+void BEZ_cross_product(double* vec0, double* vec1, double* result);
+void BEZ_bbox(int* num_nodes, double* nodes, double* left, double* right,
     double* bottom, double* top);
-void wiggle_interval(double* value, double* result, bool* success);
-void contains_nd(int* num_nodes, int* dimension, double* nodes, double* point,
+void BEZ_wiggle_interval(double* value, double* result, bool* success);
+void BEZ_contains_nd(int* num_nodes, int* dimension, double* nodes, double* point,
     bool* predicate);
-bool vector_close(int* num_values, double* vec1, double* vec2, double* eps);
-bool in_interval(double* value, double* start, double* end);
-void simple_convex_hull(
+bool BEZ_vector_close(int* num_values, double* vec1, double* vec2, double* eps);
+bool BEZ_in_interval(double* value, double* start, double* end);
+void BEZ_simple_convex_hull(
     int* num_points, double* points, int* polygon_size, double* polygon);
-void polygon_collide(int* polygon_size1, double* polygon1, int* polygon_size2,
+void BEZ_polygon_collide(int* polygon_size1, double* polygon1, int* polygon_size2,
     double* polygon2, bool* collision);
 
 #if defined(__cplusplus)

--- a/src/fortran/include/bezier/surface.h
+++ b/src/fortran/include/bezier/surface.h
@@ -25,14 +25,16 @@ void BEZ_de_casteljau_one_round(int* num_nodes, int* dimension, double* nodes,
 void BEZ_evaluate_barycentric(int* num_nodes, int* dimension, double* nodes,
     int* degree, double* lambda1, double* lambda2, double* lambda3,
     double* point);
-void BEZ_evaluate_barycentric_multi(int* num_nodes, int* dimension, double* nodes,
-    int* degree, int* num_vals, double* param_vals, double* evaluated);
-void BEZ_evaluate_cartesian_multi(int* num_nodes, int* dimension, double* nodes,
-    int* degree, int* num_vals, double* param_vals, double* evaluated);
-void BEZ_jacobian_both(int* num_nodes, int* dimension, double* nodes, int* degree,
-    double* new_nodes);
-void BEZ_jacobian_det(int* num_nodes, double* nodes, int* degree, int* num_vals,
-    double* param_vals, double* evaluated);
+void BEZ_evaluate_barycentric_multi(int* num_nodes, int* dimension,
+    double* nodes, int* degree, int* num_vals, double* param_vals,
+    double* evaluated);
+void BEZ_evaluate_cartesian_multi(int* num_nodes, int* dimension,
+    double* nodes, int* degree, int* num_vals, double* param_vals,
+    double* evaluated);
+void BEZ_jacobian_both(int* num_nodes, int* dimension, double* nodes,
+    int* degree, double* new_nodes);
+void BEZ_jacobian_det(int* num_nodes, double* nodes, int* degree,
+    int* num_vals, double* param_vals, double* evaluated);
 void BEZ_specialize_surface(int* num_nodes, int* dimension, double* nodes,
     int* degree, double* weights_a, double* weights_b, double* weights_c,
     double* specialized);

--- a/src/fortran/include/bezier/surface.h
+++ b/src/fortran/include/bezier/surface.h
@@ -19,29 +19,29 @@
 extern "C" {
 #endif
 
-void de_casteljau_one_round(int* num_nodes, int* dimension, double* nodes,
+void BEZ_de_casteljau_one_round(int* num_nodes, int* dimension, double* nodes,
     int* degree, double* lambda1, double* lambda2, double* lambda3,
     double* new_nodes);
-void evaluate_barycentric(int* num_nodes, int* dimension, double* nodes,
+void BEZ_evaluate_barycentric(int* num_nodes, int* dimension, double* nodes,
     int* degree, double* lambda1, double* lambda2, double* lambda3,
     double* point);
-void evaluate_barycentric_multi(int* num_nodes, int* dimension, double* nodes,
+void BEZ_evaluate_barycentric_multi(int* num_nodes, int* dimension, double* nodes,
     int* degree, int* num_vals, double* param_vals, double* evaluated);
-void evaluate_cartesian_multi(int* num_nodes, int* dimension, double* nodes,
+void BEZ_evaluate_cartesian_multi(int* num_nodes, int* dimension, double* nodes,
     int* degree, int* num_vals, double* param_vals, double* evaluated);
-void jacobian_both(int* num_nodes, int* dimension, double* nodes, int* degree,
+void BEZ_jacobian_both(int* num_nodes, int* dimension, double* nodes, int* degree,
     double* new_nodes);
-void jacobian_det(int* num_nodes, double* nodes, int* degree, int* num_vals,
+void BEZ_jacobian_det(int* num_nodes, double* nodes, int* degree, int* num_vals,
     double* param_vals, double* evaluated);
-void specialize_surface(int* num_nodes, int* dimension, double* nodes,
+void BEZ_specialize_surface(int* num_nodes, int* dimension, double* nodes,
     int* degree, double* weights_a, double* weights_b, double* weights_c,
     double* specialized);
-void subdivide_nodes_surface(int* num_nodes, int* dimension, double* nodes,
+void BEZ_subdivide_nodes_surface(int* num_nodes, int* dimension, double* nodes,
     int* degree, double* nodes_a, double* nodes_b, double* nodes_c,
     double* nodes_d);
-void compute_edge_nodes(int* num_nodes, int* dimension, double* nodes,
+void BEZ_compute_edge_nodes(int* num_nodes, int* dimension, double* nodes,
     int* degree, double* nodes1, double* nodes2, double* nodes3);
-void compute_area(int* num_edges, int* sizes, double** nodes_pointers,
+void BEZ_compute_area(int* num_edges, int* sizes, double** nodes_pointers,
     double* area, bool* not_implemented);
 
 #if defined(__cplusplus)

--- a/src/fortran/include/bezier/surface_intersection.h
+++ b/src/fortran/include/bezier/surface_intersection.h
@@ -31,16 +31,16 @@ typedef struct CurvedPolygonSegment {
     int edge_index;
 } CurvedPolygonSegment;
 
-void newton_refine_surface(int* num_nodes, double* nodes, int* degree,
+void BEZ_newton_refine_surface(int* num_nodes, double* nodes, int* degree,
     double* x_val, double* y_val, double* s, double* t, double* updated_s,
     double* updated_t);
-void locate_point_surface(int* num_nodes, double* nodes, int* degree,
+void BEZ_locate_point_surface(int* num_nodes, double* nodes, int* degree,
     double* x_val, double* y_val, double* s_val, double* t_val);
-void surface_intersections(int* num_nodes1, double* nodes1, int* degree1,
+void BEZ_surface_intersections(int* num_nodes1, double* nodes1, int* degree1,
     int* num_nodes2, double* nodes2, int* degree2, int* segment_ends_size,
     int* segment_ends, int* segments_size, CurvedPolygonSegment* segments,
     int* num_intersected, SurfaceContained* contained, Status* status);
-void free_surface_intersections_workspace(void);
+void BEZ_free_surface_intersections_workspace(void);
 
 #if defined(__cplusplus)
 }

--- a/src/fortran/surface.f90
+++ b/src/fortran/surface.f90
@@ -29,7 +29,7 @@ contains
   subroutine de_casteljau_one_round( &
        num_nodes, dimension_, nodes, degree, &
        lambda1, lambda2, lambda3, new_nodes) &
-       bind(c, name='de_casteljau_one_round')
+       bind(c, name='BEZ_de_casteljau_one_round')
 
     ! NOTE: This is de Casteljau on a Bezier surface / triangle.
 
@@ -77,7 +77,7 @@ contains
   subroutine evaluate_barycentric( &
        num_nodes, dimension_, nodes, degree, &
        lambda1, lambda2, lambda3, point) &
-       bind(c, name='evaluate_barycentric')
+       bind(c, name='BEZ_evaluate_barycentric')
 
     ! NOTE: This evaluation is on a Bezier surface / triangle.
     ! NOTE: This assumes degree >= 1.
@@ -102,7 +102,7 @@ contains
 
   subroutine evaluate_barycentric_multi( &
        num_nodes, dimension_, nodes, degree, num_vals, param_vals, evaluated) &
-       bind(c, name='evaluate_barycentric_multi')
+       bind(c, name='BEZ_evaluate_barycentric_multi')
 
     ! NOTE: This evaluation is on a Bezier surface / triangle.
     ! NOTE: This assumes degree >= 1.
@@ -156,7 +156,7 @@ contains
 
   subroutine evaluate_cartesian_multi( &
        num_nodes, dimension_, nodes, degree, num_vals, param_vals, evaluated) &
-       bind(c, name='evaluate_cartesian_multi')
+       bind(c, name='BEZ_evaluate_cartesian_multi')
 
     ! NOTE: This evaluation is on a Bezier surface / triangle.
     ! NOTE: This mostly copies evaluate_barycentric_multi but does not just
@@ -214,7 +214,7 @@ contains
 
   subroutine jacobian_both( &
        num_nodes, dimension_, nodes, degree, new_nodes) &
-       bind(c, name='jacobian_both')
+       bind(c, name='BEZ_jacobian_both')
 
     integer(c_int), intent(in) :: num_nodes, dimension_
     real(c_double), intent(in) :: nodes(dimension_, num_nodes)
@@ -248,7 +248,7 @@ contains
 
   subroutine jacobian_det( &
        num_nodes, nodes, degree, num_vals, param_vals, evaluated) &
-       bind(c, name='jacobian_det')
+       bind(c, name='BEZ_jacobian_det')
 
     integer(c_int), intent(in) :: num_nodes
     real(c_double), intent(in) :: nodes(2, num_nodes)
@@ -357,7 +357,7 @@ contains
   subroutine specialize_surface( &
        num_nodes, dimension_, nodes, degree, &
        weights_a, weights_b, weights_c, specialized) &
-       bind(c, name='specialize_surface')
+       bind(c, name='BEZ_specialize_surface')
 
     ! This re-parameterizes by "specializing" to a subregion of the unit
     ! triangle. This happens in waves by applying one round of de Casteljau
@@ -502,7 +502,7 @@ contains
   subroutine subdivide_nodes( &
        num_nodes, dimension_, nodes, degree, &
        nodes_a, nodes_b, nodes_c, nodes_d) &
-       bind(c, name='subdivide_nodes_surface')
+       bind(c, name='BEZ_subdivide_nodes_surface')
 
     integer(c_int), intent(in) :: num_nodes, dimension_
     real(c_double), intent(in) :: nodes(dimension_, num_nodes)
@@ -769,7 +769,7 @@ contains
 
   subroutine compute_edge_nodes( &
        num_nodes, dimension_, nodes, degree, nodes1, nodes2, nodes3) &
-       bind(c, name='compute_edge_nodes')
+       bind(c, name='BEZ_compute_edge_nodes')
 
     integer(c_int), intent(in) :: num_nodes, dimension_
     real(c_double), intent(in) :: nodes(dimension_, num_nodes)
@@ -846,7 +846,7 @@ contains
 
   subroutine compute_area( &
        num_edges, sizes, nodes_pointers, area, not_implemented) &
-       bind(c, name='compute_area')
+       bind(c, name='BEZ_compute_area')
 
     integer(c_int), intent(in) :: num_edges
     integer(c_int), intent(in) :: sizes(num_edges)

--- a/src/fortran/surface_intersection.f90
+++ b/src/fortran/surface_intersection.f90
@@ -134,7 +134,7 @@ contains
   subroutine newton_refine( &
        num_nodes, nodes, degree, x_val, y_val, &
        s, t, updated_s, updated_t) &
-       bind(c, name='newton_refine_surface')
+       bind(c, name='BEZ_newton_refine_surface')
 
     integer(c_int), intent(in) :: num_nodes
     real(c_double), intent(in) :: nodes(2, num_nodes)
@@ -287,7 +287,7 @@ contains
 
   subroutine locate_point( &
        num_nodes, nodes, degree, x_val, y_val, s_val, t_val) &
-       bind(c, name='locate_point_surface')
+       bind(c, name='BEZ_locate_point_surface')
 
     ! NOTE: This solves the inverse problem B(s, t) = (x, y) (if it can be
     !       solved). Does so by subdividing the surface until the sub-surfaces
@@ -1773,7 +1773,7 @@ contains
        num_nodes2, nodes2, degree2, &
        segment_ends_size, segment_ends, segments_size, segments, &
        num_intersected, contained, status) &
-       bind(c, name='surface_intersections')
+       bind(c, name='BEZ_surface_intersections')
 
     ! NOTE: The number of intersections cannot be known beforehand. If
     !       ``segment_ends`` is not large enough, then it will not be
@@ -1849,7 +1849,7 @@ contains
   end subroutine surfaces_intersect_abi
 
   subroutine free_surface_intersections_workspace() &
-       bind(c, name='free_surface_intersections_workspace')
+       bind(c, name='BEZ_free_surface_intersections_workspace')
 
     ! NOTE: This **should** be run during clean-up for any code which
     !       invokes ``surfaces_intersect_abi()``.

--- a/src/python/bezier/_curve.pxd
+++ b/src/python/bezier/_curve.pxd
@@ -17,27 +17,38 @@ from libcpp cimport bool as bool_t
 
 
 cdef extern from "bezier/curve.h":
-    void evaluate_curve_barycentric(int* num_nodes, int* dimension, double* nodes,
+    void evaluate_curve_barycentric "BEZ_evaluate_curve_barycentric" (
+        int* num_nodes, int* dimension, double* nodes,
         int* num_vals, double* lambda1, double* lambda2, double* evaluated)
-    void evaluate_multi(int* num_nodes, int* dimension, double* nodes,
+    void evaluate_multi "BEZ_evaluate_multi" (
+        int* num_nodes, int* dimension, double* nodes,
         int* num_vals, double* s_vals, double* evaluated)
-    void specialize_curve(int* num_nodes, int* dimension, double* nodes,
+    void specialize_curve "BEZ_specialize_curve" (
+        int* num_nodes, int* dimension, double* nodes,
         double* start, double* end, double* new_nodes)
-    void evaluate_hodograph(double* s, int* num_nodes, int* dimension,
+    void evaluate_hodograph "BEZ_evaluate_hodograph" (
+        double* s, int* num_nodes, int* dimension,
         double* nodes, double* hodograph)
-    void subdivide_nodes_curve(int* num_nodes, int* dimension, double* nodes,
+    void subdivide_nodes_curve "BEZ_subdivide_nodes_curve" (
+        int* num_nodes, int* dimension, double* nodes,
         double* left_nodes, double* right_nodes)
-    void newton_refine_curve(int* num_nodes, int* dimension, double* nodes,
+    void newton_refine_curve "BEZ_newton_refine_curve" (
+        int* num_nodes, int* dimension, double* nodes,
         double* point, double* s, double* updated_s)
-    void locate_point_curve(int* num_nodes, int* dimension, double* nodes,
+    void locate_point_curve "BEZ_locate_point_curve" (
+        int* num_nodes, int* dimension, double* nodes,
         double* point, double* s_approx)
-    void elevate_nodes_curve(
+    void elevate_nodes_curve "BEZ_elevate_nodes_curve" (
         int* num_nodes, int* dimension, double* nodes, double* elevated)
-    void get_curvature(int* num_nodes, double* nodes, double* tangent_vec,
+    void get_curvature "BEZ_get_curvature" (
+        int* num_nodes, double* nodes, double* tangent_vec,
         double* s, double* curvature)
-    void reduce_pseudo_inverse(int* num_nodes, int* dimension, double* nodes,
+    void reduce_pseudo_inverse "BEZ_reduce_pseudo_inverse" (
+        int* num_nodes, int* dimension, double* nodes,
         double* reduced, bool_t* not_implemented)
-    void full_reduce(int* num_nodes, int* dimension, double* nodes,
+    void full_reduce "BEZ_full_reduce" (
+        int* num_nodes, int* dimension, double* nodes,
         int* num_reduced_nodes, double* reduced, bool_t* not_implemented)
-    void compute_length(int* num_nodes, int* dimension, double* nodes,
+    void compute_length "BEZ_compute_length" (
+        int* num_nodes, int* dimension, double* nodes,
         double* length, int* error_val)

--- a/src/python/bezier/_curve_intersection.pxd
+++ b/src/python/bezier/_curve_intersection.pxd
@@ -24,13 +24,16 @@ cdef extern from "bezier/curve_intersection.h":
         TANGENT = 1
         DISJOINT = 2
 
-    void newton_refine_curve_intersect(double* s, int* num_nodes1, double* nodes1,
+    void newton_refine_curve_intersect "BEZ_newton_refine_curve_intersect" (
+        double* s, int* num_nodes1, double* nodes1,
         double* t, int* num_nodes2, double* nodes2, double* new_s, double* new_t,
         Status* status)
-    void bbox_intersect(int* num_nodes1, double* nodes1, int* num_nodes2,
+    void bbox_intersect "BEZ_bbox_intersect" (
+        int* num_nodes1, double* nodes1, int* num_nodes2,
         double* nodes2, BoxIntersectionType* enum_)
-    void curve_intersections(int* num_nodes_first, double* nodes_first,
+    void curve_intersections "BEZ_curve_intersections" (
+        int* num_nodes_first, double* nodes_first,
         int* num_nodes_second, double* nodes_second, int* intersections_size,
         double* intersections, int* num_intersections, bool_t* coincident,
         Status* status)
-    void free_curve_intersections_workspace()
+    void free_curve_intersections_workspace "BEZ_free_curve_intersections_workspace" ()

--- a/src/python/bezier/_helpers.pxd
+++ b/src/python/bezier/_helpers.pxd
@@ -17,15 +17,22 @@ from libcpp cimport bool as bool_t
 
 
 cdef extern from "bezier/helpers.h":
-    void cross_product(double* vec0, double* vec1, double* result)
-    void bbox(int* num_nodes, double* nodes, double* left, double* right,
+    void cross_product "BEZ_cross_product" (
+        double* vec0, double* vec1, double* result)
+    void bbox "BEZ_bbox" (
+        int* num_nodes, double* nodes, double* left, double* right,
         double* bottom, double* top)
-    void wiggle_interval(double* value, double* result, bool_t* success)
-    void contains_nd(int* num_nodes, int* dimension, double* nodes, double* point,
+    void wiggle_interval "BEZ_wiggle_interval" (
+        double* value, double* result, bool_t* success)
+    void contains_nd "BEZ_contains_nd" (
+        int* num_nodes, int* dimension, double* nodes, double* point,
         bool_t* predicate)
-    bool_t vector_close(int* num_values, double* vec1, double* vec2, double* eps)
-    bool_t in_interval(double* value, double* start, double* end)
-    void simple_convex_hull(
+    bool_t vector_close "BEZ_vector_close" (
+        int* num_values, double* vec1, double* vec2, double* eps)
+    bool_t in_interval "BEZ_in_interval" (
+        double* value, double* start, double* end)
+    void simple_convex_hull "BEZ_simple_convex_hull" (
         int* num_points, double* points, int* polygon_size, double* polygon)
-    void polygon_collide(int* polygon_size1, double* polygon1, int* polygon_size2,
+    void polygon_collide "BEZ_polygon_collide" (
+        int* polygon_size1, double* polygon1, int* polygon_size2,
         double* polygon2, bool_t* collision)

--- a/src/python/bezier/_speedup.c
+++ b/src/python/bezier/_speedup.c
@@ -3634,7 +3634,7 @@ static PyObject *__pyx_pf_6bezier_8_speedup_evaluate_multi_barycentric(CYTHON_UN
  *         &num_nodes,
  *         &dimension,
  */
-  evaluate_curve_barycentric((&__pyx_v_num_nodes), (&__pyx_v_dimension), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ ((char *) (((double *) __pyx_v_nodes.data) + __pyx_t_12)) ) + __pyx_t_13 * __pyx_v_nodes.strides[1]) )))), (&__pyx_v_num_vals), (&(*((double *) ( /* dim=0 */ ((char *) (((double *) __pyx_v_lambda1.data) + __pyx_t_14)) )))), (&(*((double *) ( /* dim=0 */ ((char *) (((double *) __pyx_v_lambda2.data) + __pyx_t_15)) )))), (&(*__Pyx_BufPtrFortranContig2d(double *, __pyx_pybuffernd_evaluated.rcbuffer->pybuffer.buf, __pyx_t_16, __pyx_pybuffernd_evaluated.diminfo[0].strides, __pyx_t_17, __pyx_pybuffernd_evaluated.diminfo[1].strides))));
+  BEZ_evaluate_curve_barycentric((&__pyx_v_num_nodes), (&__pyx_v_dimension), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ ((char *) (((double *) __pyx_v_nodes.data) + __pyx_t_12)) ) + __pyx_t_13 * __pyx_v_nodes.strides[1]) )))), (&__pyx_v_num_vals), (&(*((double *) ( /* dim=0 */ ((char *) (((double *) __pyx_v_lambda1.data) + __pyx_t_14)) )))), (&(*((double *) ( /* dim=0 */ ((char *) (((double *) __pyx_v_lambda2.data) + __pyx_t_15)) )))), (&(*__Pyx_BufPtrFortranContig2d(double *, __pyx_pybuffernd_evaluated.rcbuffer->pybuffer.buf, __pyx_t_16, __pyx_pybuffernd_evaluated.diminfo[0].strides, __pyx_t_17, __pyx_pybuffernd_evaluated.diminfo[1].strides))));
 
   /* "bezier/_speedup.pyx":140
  *         &evaluated[0, 0],
@@ -4036,7 +4036,7 @@ static PyObject *__pyx_pf_6bezier_8_speedup_2evaluate_multi(CYTHON_UNUSED PyObje
  *         &num_nodes,
  *         &dimension,
  */
-  evaluate_multi((&__pyx_v_num_nodes), (&__pyx_v_dimension), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ ((char *) (((double *) __pyx_v_nodes.data) + __pyx_t_12)) ) + __pyx_t_13 * __pyx_v_nodes.strides[1]) )))), (&__pyx_v_num_vals), (&(*((double *) ( /* dim=0 */ ((char *) (((double *) __pyx_v_s_vals.data) + __pyx_t_14)) )))), (&(*__Pyx_BufPtrFortranContig2d(double *, __pyx_pybuffernd_evaluated.rcbuffer->pybuffer.buf, __pyx_t_15, __pyx_pybuffernd_evaluated.diminfo[0].strides, __pyx_t_16, __pyx_pybuffernd_evaluated.diminfo[1].strides))));
+  BEZ_evaluate_multi((&__pyx_v_num_nodes), (&__pyx_v_dimension), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ ((char *) (((double *) __pyx_v_nodes.data) + __pyx_t_12)) ) + __pyx_t_13 * __pyx_v_nodes.strides[1]) )))), (&__pyx_v_num_vals), (&(*((double *) ( /* dim=0 */ ((char *) (((double *) __pyx_v_s_vals.data) + __pyx_t_14)) )))), (&(*__Pyx_BufPtrFortranContig2d(double *, __pyx_pybuffernd_evaluated.rcbuffer->pybuffer.buf, __pyx_t_15, __pyx_pybuffernd_evaluated.diminfo[0].strides, __pyx_t_16, __pyx_pybuffernd_evaluated.diminfo[1].strides))));
 
   /* "bezier/_speedup.pyx":159
  *         &evaluated[0, 0],
@@ -4364,7 +4364,7 @@ static PyObject *__pyx_pf_6bezier_8_speedup_4specialize_curve(CYTHON_UNUSED PyOb
  *         &num_nodes,
  *         &dimension,
  */
-  specialize_curve((&__pyx_v_num_nodes), (&__pyx_v_dimension), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ ((char *) (((double *) __pyx_v_nodes.data) + __pyx_t_12)) ) + __pyx_t_13 * __pyx_v_nodes.strides[1]) )))), (&__pyx_v_start), (&__pyx_v_end), (&(*__Pyx_BufPtrFortranContig2d(double *, __pyx_pybuffernd_new_nodes.rcbuffer->pybuffer.buf, __pyx_t_14, __pyx_pybuffernd_new_nodes.diminfo[0].strides, __pyx_t_15, __pyx_pybuffernd_new_nodes.diminfo[1].strides))));
+  BEZ_specialize_curve((&__pyx_v_num_nodes), (&__pyx_v_dimension), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ ((char *) (((double *) __pyx_v_nodes.data) + __pyx_t_12)) ) + __pyx_t_13 * __pyx_v_nodes.strides[1]) )))), (&__pyx_v_start), (&__pyx_v_end), (&(*__Pyx_BufPtrFortranContig2d(double *, __pyx_pybuffernd_new_nodes.rcbuffer->pybuffer.buf, __pyx_t_14, __pyx_pybuffernd_new_nodes.diminfo[0].strides, __pyx_t_15, __pyx_pybuffernd_new_nodes.diminfo[1].strides))));
 
   /* "bezier/_speedup.pyx":178
  *     )
@@ -4678,7 +4678,7 @@ static PyObject *__pyx_pf_6bezier_8_speedup_6evaluate_hodograph(CYTHON_UNUSED Py
  *         &s,
  *         &num_nodes,
  */
-  evaluate_hodograph((&__pyx_v_s), (&__pyx_v_num_nodes), (&__pyx_v_dimension), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ ((char *) (((double *) __pyx_v_nodes.data) + __pyx_t_12)) ) + __pyx_t_13 * __pyx_v_nodes.strides[1]) )))), (&(*__Pyx_BufPtrFortranContig2d(double *, __pyx_pybuffernd_hodograph.rcbuffer->pybuffer.buf, __pyx_t_14, __pyx_pybuffernd_hodograph.diminfo[0].strides, __pyx_t_15, __pyx_pybuffernd_hodograph.diminfo[1].strides))));
+  BEZ_evaluate_hodograph((&__pyx_v_s), (&__pyx_v_num_nodes), (&__pyx_v_dimension), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ ((char *) (((double *) __pyx_v_nodes.data) + __pyx_t_12)) ) + __pyx_t_13 * __pyx_v_nodes.strides[1]) )))), (&(*__Pyx_BufPtrFortranContig2d(double *, __pyx_pybuffernd_hodograph.rcbuffer->pybuffer.buf, __pyx_t_14, __pyx_pybuffernd_hodograph.diminfo[0].strides, __pyx_t_15, __pyx_pybuffernd_hodograph.diminfo[1].strides))));
 
   /* "bezier/_speedup.pyx":196
  *     )
@@ -5035,7 +5035,7 @@ static PyObject *__pyx_pf_6bezier_8_speedup_8subdivide_nodes_curve(CYTHON_UNUSED
  *         &num_nodes,
  *         &dimension,
  */
-  subdivide_nodes_curve((&__pyx_v_num_nodes), (&__pyx_v_dimension), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ ((char *) (((double *) __pyx_v_nodes.data) + __pyx_t_12)) ) + __pyx_t_13 * __pyx_v_nodes.strides[1]) )))), (&(*__Pyx_BufPtrFortranContig2d(double *, __pyx_pybuffernd_left_nodes.rcbuffer->pybuffer.buf, __pyx_t_14, __pyx_pybuffernd_left_nodes.diminfo[0].strides, __pyx_t_15, __pyx_pybuffernd_left_nodes.diminfo[1].strides))), (&(*__Pyx_BufPtrFortranContig2d(double *, __pyx_pybuffernd_right_nodes.rcbuffer->pybuffer.buf, __pyx_t_16, __pyx_pybuffernd_right_nodes.diminfo[0].strides, __pyx_t_17, __pyx_pybuffernd_right_nodes.diminfo[1].strides))));
+  BEZ_subdivide_nodes_curve((&__pyx_v_num_nodes), (&__pyx_v_dimension), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ ((char *) (((double *) __pyx_v_nodes.data) + __pyx_t_12)) ) + __pyx_t_13 * __pyx_v_nodes.strides[1]) )))), (&(*__Pyx_BufPtrFortranContig2d(double *, __pyx_pybuffernd_left_nodes.rcbuffer->pybuffer.buf, __pyx_t_14, __pyx_pybuffernd_left_nodes.diminfo[0].strides, __pyx_t_15, __pyx_pybuffernd_left_nodes.diminfo[1].strides))), (&(*__Pyx_BufPtrFortranContig2d(double *, __pyx_pybuffernd_right_nodes.rcbuffer->pybuffer.buf, __pyx_t_16, __pyx_pybuffernd_right_nodes.diminfo[0].strides, __pyx_t_17, __pyx_pybuffernd_right_nodes.diminfo[1].strides))));
 
   /* "bezier/_speedup.pyx":216
  *     )
@@ -5303,7 +5303,7 @@ static PyObject *__pyx_pf_6bezier_8_speedup_10newton_refine_curve(CYTHON_UNUSED 
  *         &num_nodes,
  *         &dimension,
  */
-  newton_refine_curve((&__pyx_v_num_nodes), (&__pyx_v_dimension), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ ((char *) (((double *) __pyx_v_nodes.data) + __pyx_t_8)) ) + __pyx_t_9 * __pyx_v_nodes.strides[1]) )))), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ ((char *) (((double *) __pyx_v_point.data) + __pyx_t_10)) ) + __pyx_t_11 * __pyx_v_point.strides[1]) )))), (&__pyx_v_s), (&__pyx_v_updated_s));
+  BEZ_newton_refine_curve((&__pyx_v_num_nodes), (&__pyx_v_dimension), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ ((char *) (((double *) __pyx_v_nodes.data) + __pyx_t_8)) ) + __pyx_t_9 * __pyx_v_nodes.strides[1]) )))), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ ((char *) (((double *) __pyx_v_point.data) + __pyx_t_10)) ) + __pyx_t_11 * __pyx_v_point.strides[1]) )))), (&__pyx_v_s), (&__pyx_v_updated_s));
 
   /* "bezier/_speedup.pyx":236
  *     )
@@ -5543,7 +5543,7 @@ static PyObject *__pyx_pf_6bezier_8_speedup_12locate_point_curve(CYTHON_UNUSED P
  *         &num_nodes,
  *         &dimension,
  */
-  locate_point_curve((&__pyx_v_num_nodes), (&__pyx_v_dimension), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ ((char *) (((double *) __pyx_v_nodes.data) + __pyx_t_8)) ) + __pyx_t_9 * __pyx_v_nodes.strides[1]) )))), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ ((char *) (((double *) __pyx_v_point.data) + __pyx_t_10)) ) + __pyx_t_11 * __pyx_v_point.strides[1]) )))), (&__pyx_v_s_approx));
+  BEZ_locate_point_curve((&__pyx_v_num_nodes), (&__pyx_v_dimension), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ ((char *) (((double *) __pyx_v_nodes.data) + __pyx_t_8)) ) + __pyx_t_9 * __pyx_v_nodes.strides[1]) )))), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ ((char *) (((double *) __pyx_v_point.data) + __pyx_t_10)) ) + __pyx_t_11 * __pyx_v_point.strides[1]) )))), (&__pyx_v_s_approx));
 
   /* "bezier/_speedup.pyx":254
  *     )
@@ -5878,7 +5878,7 @@ static PyObject *__pyx_pf_6bezier_8_speedup_14elevate_nodes(CYTHON_UNUSED PyObje
  *         &num_nodes,
  *         &dimension,
  */
-  elevate_nodes_curve((&__pyx_v_num_nodes), (&__pyx_v_dimension), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ ((char *) (((double *) __pyx_v_nodes.data) + __pyx_t_12)) ) + __pyx_t_13 * __pyx_v_nodes.strides[1]) )))), (&(*__Pyx_BufPtrFortranContig2d(double *, __pyx_pybuffernd_elevated.rcbuffer->pybuffer.buf, __pyx_t_14, __pyx_pybuffernd_elevated.diminfo[0].strides, __pyx_t_15, __pyx_pybuffernd_elevated.diminfo[1].strides))));
+  BEZ_elevate_nodes_curve((&__pyx_v_num_nodes), (&__pyx_v_dimension), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ ((char *) (((double *) __pyx_v_nodes.data) + __pyx_t_12)) ) + __pyx_t_13 * __pyx_v_nodes.strides[1]) )))), (&(*__Pyx_BufPtrFortranContig2d(double *, __pyx_pybuffernd_elevated.rcbuffer->pybuffer.buf, __pyx_t_14, __pyx_pybuffernd_elevated.diminfo[0].strides, __pyx_t_15, __pyx_pybuffernd_elevated.diminfo[1].strides))));
 
   /* "bezier/_speedup.pyx":277
  *     )
@@ -6133,7 +6133,7 @@ static PyObject *__pyx_pf_6bezier_8_speedup_16get_curvature(CYTHON_UNUSED PyObje
  *         &num_nodes,
  *         &nodes[0, 0],
  */
-  get_curvature((&__pyx_v_num_nodes), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ ((char *) (((double *) __pyx_v_nodes.data) + __pyx_t_7)) ) + __pyx_t_8 * __pyx_v_nodes.strides[1]) )))), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ ((char *) (((double *) __pyx_v_tangent_vec.data) + __pyx_t_9)) ) + __pyx_t_10 * __pyx_v_tangent_vec.strides[1]) )))), (&__pyx_v_s), (&__pyx_v_curvature));
+  BEZ_get_curvature((&__pyx_v_num_nodes), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ ((char *) (((double *) __pyx_v_nodes.data) + __pyx_t_7)) ) + __pyx_t_8 * __pyx_v_nodes.strides[1]) )))), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ ((char *) (((double *) __pyx_v_tangent_vec.data) + __pyx_t_9)) ) + __pyx_t_10 * __pyx_v_tangent_vec.strides[1]) )))), (&__pyx_v_s), (&__pyx_v_curvature));
 
   /* "bezier/_speedup.pyx":296
  *     )
@@ -6408,7 +6408,7 @@ static PyObject *__pyx_pf_6bezier_8_speedup_18reduce_pseudo_inverse(CYTHON_UNUSE
  *         &num_nodes,
  *         &dimension,
  */
-  reduce_pseudo_inverse((&__pyx_v_num_nodes), (&__pyx_v_dimension), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ ((char *) (((double *) __pyx_v_nodes.data) + __pyx_t_12)) ) + __pyx_t_13 * __pyx_v_nodes.strides[1]) )))), (&(*__Pyx_BufPtrFortranContig2d(double *, __pyx_pybuffernd_reduced.rcbuffer->pybuffer.buf, __pyx_t_14, __pyx_pybuffernd_reduced.diminfo[0].strides, __pyx_t_15, __pyx_pybuffernd_reduced.diminfo[1].strides))), (&__pyx_v_not_implemented));
+  BEZ_reduce_pseudo_inverse((&__pyx_v_num_nodes), (&__pyx_v_dimension), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ ((char *) (((double *) __pyx_v_nodes.data) + __pyx_t_12)) ) + __pyx_t_13 * __pyx_v_nodes.strides[1]) )))), (&(*__Pyx_BufPtrFortranContig2d(double *, __pyx_pybuffernd_reduced.rcbuffer->pybuffer.buf, __pyx_t_14, __pyx_pybuffernd_reduced.diminfo[0].strides, __pyx_t_15, __pyx_pybuffernd_reduced.diminfo[1].strides))), (&__pyx_v_not_implemented));
 
   /* "bezier/_speedup.pyx":316
  *     )
@@ -6758,7 +6758,7 @@ static PyObject *__pyx_pf_6bezier_8_speedup_20full_reduce(CYTHON_UNUSED PyObject
  *         &num_nodes,
  *         &dimension,
  */
-  full_reduce((&__pyx_v_num_nodes), (&__pyx_v_dimension), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ ((char *) (((double *) __pyx_v_nodes.data) + __pyx_t_12)) ) + __pyx_t_13 * __pyx_v_nodes.strides[1]) )))), (&__pyx_v_num_reduced_nodes), (&(*__Pyx_BufPtrFortranContig2d(double *, __pyx_pybuffernd_reduced.rcbuffer->pybuffer.buf, __pyx_t_14, __pyx_pybuffernd_reduced.diminfo[0].strides, __pyx_t_15, __pyx_pybuffernd_reduced.diminfo[1].strides))), (&__pyx_v_not_implemented));
+  BEZ_full_reduce((&__pyx_v_num_nodes), (&__pyx_v_dimension), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ ((char *) (((double *) __pyx_v_nodes.data) + __pyx_t_12)) ) + __pyx_t_13 * __pyx_v_nodes.strides[1]) )))), (&__pyx_v_num_reduced_nodes), (&(*__Pyx_BufPtrFortranContig2d(double *, __pyx_pybuffernd_reduced.rcbuffer->pybuffer.buf, __pyx_t_14, __pyx_pybuffernd_reduced.diminfo[0].strides, __pyx_t_15, __pyx_pybuffernd_reduced.diminfo[1].strides))), (&__pyx_v_not_implemented));
 
   /* "bezier/_speedup.pyx":343
  *     )
@@ -7150,7 +7150,7 @@ static PyObject *__pyx_pf_6bezier_8_speedup_22compute_length(CYTHON_UNUSED PyObj
  *         &num_nodes,
  *         &dimension,
  */
-  compute_length((&__pyx_v_num_nodes), (&__pyx_v_dimension), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ ((char *) (((double *) __pyx_v_nodes.data) + __pyx_t_8)) ) + __pyx_t_9 * __pyx_v_nodes.strides[1]) )))), (&__pyx_v_length), (&__pyx_v_error_val));
+  BEZ_compute_length((&__pyx_v_num_nodes), (&__pyx_v_dimension), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ ((char *) (((double *) __pyx_v_nodes.data) + __pyx_t_8)) ) + __pyx_t_9 * __pyx_v_nodes.strides[1]) )))), (&__pyx_v_length), (&__pyx_v_error_val));
 
   /* "bezier/_speedup.pyx":373
  *     )
@@ -7730,7 +7730,7 @@ static PyObject *__pyx_pf_6bezier_8_speedup_24newton_refine_curve_intersect(CYTH
  *         &s,
  *         &num_nodes1,
  */
-  newton_refine_curve_intersect((&__pyx_v_s), (&__pyx_v_num_nodes1), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ ((char *) (((double *) __pyx_v_nodes1.data) + __pyx_t_7)) ) + __pyx_t_8 * __pyx_v_nodes1.strides[1]) )))), (&__pyx_v_t), (&__pyx_v_num_nodes2), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ ((char *) (((double *) __pyx_v_nodes2.data) + __pyx_t_9)) ) + __pyx_t_10 * __pyx_v_nodes2.strides[1]) )))), (&__pyx_v_new_s), (&__pyx_v_new_t), (&__pyx_v_status));
+  BEZ_newton_refine_curve_intersect((&__pyx_v_s), (&__pyx_v_num_nodes1), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ ((char *) (((double *) __pyx_v_nodes1.data) + __pyx_t_7)) ) + __pyx_t_8 * __pyx_v_nodes1.strides[1]) )))), (&__pyx_v_t), (&__pyx_v_num_nodes2), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ ((char *) (((double *) __pyx_v_nodes2.data) + __pyx_t_9)) ) + __pyx_t_10 * __pyx_v_nodes2.strides[1]) )))), (&__pyx_v_new_s), (&__pyx_v_new_t), (&__pyx_v_status));
 
   /* "bezier/_speedup.pyx":414
  *     )
@@ -8093,7 +8093,7 @@ static PyObject *__pyx_pf_6bezier_8_speedup_26bbox_intersect(CYTHON_UNUSED PyObj
  *         &num_nodes1,
  *         &nodes1[0, 0],
  */
-  bbox_intersect((&__pyx_v_num_nodes1), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ ((char *) (((double *) __pyx_v_nodes1.data) + __pyx_t_7)) ) + __pyx_t_8 * __pyx_v_nodes1.strides[1]) )))), (&__pyx_v_num_nodes2), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ ((char *) (((double *) __pyx_v_nodes2.data) + __pyx_t_9)) ) + __pyx_t_10 * __pyx_v_nodes2.strides[1]) )))), (&__pyx_v_enum_val));
+  BEZ_bbox_intersect((&__pyx_v_num_nodes1), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ ((char *) (((double *) __pyx_v_nodes1.data) + __pyx_t_7)) ) + __pyx_t_8 * __pyx_v_nodes1.strides[1]) )))), (&__pyx_v_num_nodes2), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ ((char *) (((double *) __pyx_v_nodes2.data) + __pyx_t_9)) ) + __pyx_t_10 * __pyx_v_nodes2.strides[1]) )))), (&__pyx_v_enum_val));
 
   /* "bezier/_speedup.pyx":437
  *     )
@@ -8827,7 +8827,7 @@ static PyObject *__pyx_pf_6bezier_8_speedup_32curve_intersections(CYTHON_UNUSED 
  *         &num_nodes_first,
  *         &nodes_first[0, 0],
  */
-  curve_intersections((&__pyx_v_num_nodes_first), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ ((char *) (((double *) __pyx_v_nodes_first.data) + __pyx_t_7)) ) + __pyx_t_8 * __pyx_v_nodes_first.strides[1]) )))), (&__pyx_v_num_nodes_second), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ ((char *) (((double *) __pyx_v_nodes_second.data) + __pyx_t_9)) ) + __pyx_t_10 * __pyx_v_nodes_second.strides[1]) )))), (&__pyx_v_intersections_size), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ ((char *) (((double *) __pyx_v_6bezier_8_speedup_CURVES_WORKSPACE.data) + __pyx_t_11)) ) + __pyx_t_12 * __pyx_v_6bezier_8_speedup_CURVES_WORKSPACE.strides[1]) )))), (&__pyx_v_num_intersections), (&__pyx_v_coincident), (&__pyx_v_status));
+  BEZ_curve_intersections((&__pyx_v_num_nodes_first), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ ((char *) (((double *) __pyx_v_nodes_first.data) + __pyx_t_7)) ) + __pyx_t_8 * __pyx_v_nodes_first.strides[1]) )))), (&__pyx_v_num_nodes_second), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ ((char *) (((double *) __pyx_v_nodes_second.data) + __pyx_t_9)) ) + __pyx_t_10 * __pyx_v_nodes_second.strides[1]) )))), (&__pyx_v_intersections_size), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ ((char *) (((double *) __pyx_v_6bezier_8_speedup_CURVES_WORKSPACE.data) + __pyx_t_11)) ) + __pyx_t_12 * __pyx_v_6bezier_8_speedup_CURVES_WORKSPACE.strides[1]) )))), (&__pyx_v_num_intersections), (&__pyx_v_coincident), (&__pyx_v_status));
 
   /* "bezier/_speedup.pyx":482
  *     )
@@ -9349,7 +9349,7 @@ static PyObject *__pyx_pf_6bezier_8_speedup_34free_curve_intersections_workspace
  *
  * ############################
  */
-  free_curve_intersections_workspace();
+  BEZ_free_curve_intersections_workspace();
 
   /* "bezier/_speedup.pyx":505
  *
@@ -9470,7 +9470,7 @@ static PyObject *__pyx_pf_6bezier_8_speedup_36cross_product(CYTHON_UNUSED PyObje
  *         &vec0[0],
  *         &vec1[0],
  */
-  cross_product((&(*((double *) ( /* dim=0 */ ((char *) (((double *) __pyx_v_vec0.data) + __pyx_t_1)) )))), (&(*((double *) ( /* dim=0 */ ((char *) (((double *) __pyx_v_vec1.data) + __pyx_t_2)) )))), (&__pyx_v_result));
+  BEZ_cross_product((&(*((double *) ( /* dim=0 */ ((char *) (((double *) __pyx_v_vec0.data) + __pyx_t_1)) )))), (&(*((double *) ( /* dim=0 */ ((char *) (((double *) __pyx_v_vec1.data) + __pyx_t_2)) )))), (&__pyx_v_result));
 
   /* "bezier/_speedup.pyx":521
  *     )
@@ -9658,7 +9658,7 @@ static PyObject *__pyx_pf_6bezier_8_speedup_38bbox(CYTHON_UNUSED PyObject *__pyx
  *         &num_nodes,
  *         &nodes[0, 0],
  */
-  bbox((&__pyx_v_num_nodes), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ ((char *) (((double *) __pyx_v_nodes.data) + __pyx_t_7)) ) + __pyx_t_8 * __pyx_v_nodes.strides[1]) )))), (&__pyx_v_left), (&__pyx_v_right), (&__pyx_v_bottom), (&__pyx_v_top));
+  BEZ_bbox((&__pyx_v_num_nodes), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ ((char *) (((double *) __pyx_v_nodes.data) + __pyx_t_7)) ) + __pyx_t_8 * __pyx_v_nodes.strides[1]) )))), (&__pyx_v_left), (&__pyx_v_right), (&__pyx_v_bottom), (&__pyx_v_top));
 
   /* "bezier/_speedup.pyx":540
  *     )
@@ -9768,7 +9768,7 @@ static PyObject *__pyx_pf_6bezier_8_speedup_40wiggle_interval(CYTHON_UNUSED PyOb
  *         &value,
  *         &result,
  */
-  wiggle_interval((&__pyx_v_value), (&__pyx_v_result), (&__pyx_v_success));
+  BEZ_wiggle_interval((&__pyx_v_value), (&__pyx_v_result), (&__pyx_v_success));
 
   /* "bezier/_speedup.pyx":553
  *     )
@@ -10176,7 +10176,7 @@ static PyObject *__pyx_pf_6bezier_8_speedup_42contains_nd(CYTHON_UNUSED PyObject
  *         &num_nodes,
  *         &dimension,
  */
-  contains_nd((&__pyx_v_num_nodes), (&__pyx_v_dimension), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ ((char *) (((double *) __pyx_v_nodes.data) + __pyx_t_11)) ) + __pyx_t_12 * __pyx_v_nodes.strides[1]) )))), (&(*((double *) ( /* dim=0 */ ((char *) (((double *) __pyx_v_point.data) + __pyx_t_13)) )))), (&__pyx_v_predicate));
+  BEZ_contains_nd((&__pyx_v_num_nodes), (&__pyx_v_dimension), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ ((char *) (((double *) __pyx_v_nodes.data) + __pyx_t_11)) ) + __pyx_t_12 * __pyx_v_nodes.strides[1]) )))), (&(*((double *) ( /* dim=0 */ ((char *) (((double *) __pyx_v_point.data) + __pyx_t_13)) )))), (&__pyx_v_predicate));
 
   /* "bezier/_speedup.pyx":574
  *     )
@@ -10428,7 +10428,7 @@ static PyObject *__pyx_pf_6bezier_8_speedup_44vector_close(CYTHON_UNUSED PyObjec
  *         &num_values,
  *         &vec1[0],
  */
-  __pyx_t_1 = __Pyx_PyBool_FromLong(vector_close((&__pyx_v_num_values), (&(*((double *) ( /* dim=0 */ ((char *) (((double *) __pyx_v_vec1.data) + __pyx_t_7)) )))), (&(*((double *) ( /* dim=0 */ ((char *) (((double *) __pyx_v_vec2.data) + __pyx_t_8)) )))), (&__pyx_v_eps))); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 583, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_PyBool_FromLong(BEZ_vector_close((&__pyx_v_num_values), (&(*((double *) ( /* dim=0 */ ((char *) (((double *) __pyx_v_vec1.data) + __pyx_t_7)) )))), (&(*((double *) ( /* dim=0 */ ((char *) (((double *) __pyx_v_vec2.data) + __pyx_t_8)) )))), (&__pyx_v_eps))); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 583, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __pyx_r = __pyx_t_1;
   __pyx_t_1 = 0;
@@ -10561,7 +10561,7 @@ static PyObject *__pyx_pf_6bezier_8_speedup_46in_interval(CYTHON_UNUSED PyObject
  *     )
  *
  */
-  __pyx_t_1 = __Pyx_PyBool_FromLong(in_interval((&__pyx_v_value), (&__pyx_v_start), (&__pyx_v_end))); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 592, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_PyBool_FromLong(BEZ_in_interval((&__pyx_v_value), (&__pyx_v_start), (&__pyx_v_end))); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 592, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __pyx_r = __pyx_t_1;
   __pyx_t_1 = 0;
@@ -10814,7 +10814,7 @@ static PyObject *__pyx_pf_6bezier_8_speedup_48simple_convex_hull(CYTHON_UNUSED P
  *         &num_points,
  *         &points[0, 0],
  */
-  simple_convex_hull((&__pyx_v_num_points), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ ((char *) (((double *) __pyx_v_points.data) + __pyx_t_11)) ) + __pyx_t_12 * __pyx_v_points.strides[1]) )))), (&__pyx_v_polygon_size), (&(*__Pyx_BufPtrFortranContig2d(double *, __pyx_pybuffernd_polygon.rcbuffer->pybuffer.buf, __pyx_t_13, __pyx_pybuffernd_polygon.diminfo[0].strides, __pyx_t_14, __pyx_pybuffernd_polygon.diminfo[1].strides))));
+  BEZ_simple_convex_hull((&__pyx_v_num_points), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ ((char *) (((double *) __pyx_v_points.data) + __pyx_t_11)) ) + __pyx_t_12 * __pyx_v_points.strides[1]) )))), (&__pyx_v_polygon_size), (&(*__Pyx_BufPtrFortranContig2d(double *, __pyx_pybuffernd_polygon.rcbuffer->pybuffer.buf, __pyx_t_13, __pyx_pybuffernd_polygon.diminfo[0].strides, __pyx_t_14, __pyx_pybuffernd_polygon.diminfo[1].strides))));
 
   /* "bezier/_speedup.pyx":615
  *     )
@@ -11158,7 +11158,7 @@ static PyObject *__pyx_pf_6bezier_8_speedup_50polygon_collide(CYTHON_UNUSED PyOb
  *         &polygon_size1,
  *         &polygon1[0, 0],
  */
-  polygon_collide((&__pyx_v_polygon_size1), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ ((char *) (((double *) __pyx_v_polygon1.data) + __pyx_t_7)) ) + __pyx_t_8 * __pyx_v_polygon1.strides[1]) )))), (&__pyx_v_polygon_size2), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ ((char *) (((double *) __pyx_v_polygon2.data) + __pyx_t_9)) ) + __pyx_t_10 * __pyx_v_polygon2.strides[1]) )))), (&__pyx_v_collision));
+  BEZ_polygon_collide((&__pyx_v_polygon_size1), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ ((char *) (((double *) __pyx_v_polygon1.data) + __pyx_t_7)) ) + __pyx_t_8 * __pyx_v_polygon1.strides[1]) )))), (&__pyx_v_polygon_size2), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ ((char *) (((double *) __pyx_v_polygon2.data) + __pyx_t_9)) ) + __pyx_t_10 * __pyx_v_polygon2.strides[1]) )))), (&__pyx_v_collision));
 
   /* "bezier/_speedup.pyx":634
  *     )
@@ -11501,7 +11501,7 @@ static PyObject *__pyx_pf_6bezier_8_speedup_52de_casteljau_one_round(CYTHON_UNUS
  *         &num_nodes,
  *         &dimension,
  */
-  de_casteljau_one_round((&__pyx_v_num_nodes), (&__pyx_v_dimension), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ ((char *) (((double *) __pyx_v_nodes.data) + __pyx_t_12)) ) + __pyx_t_13 * __pyx_v_nodes.strides[1]) )))), (&__pyx_v_degree), (&__pyx_v_lambda1), (&__pyx_v_lambda2), (&__pyx_v_lambda3), (&(*__Pyx_BufPtrFortranContig2d(double *, __pyx_pybuffernd_new_nodes.rcbuffer->pybuffer.buf, __pyx_t_14, __pyx_pybuffernd_new_nodes.diminfo[0].strides, __pyx_t_15, __pyx_pybuffernd_new_nodes.diminfo[1].strides))));
+  BEZ_de_casteljau_one_round((&__pyx_v_num_nodes), (&__pyx_v_dimension), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ ((char *) (((double *) __pyx_v_nodes.data) + __pyx_t_12)) ) + __pyx_t_13 * __pyx_v_nodes.strides[1]) )))), (&__pyx_v_degree), (&__pyx_v_lambda1), (&__pyx_v_lambda2), (&__pyx_v_lambda3), (&(*__Pyx_BufPtrFortranContig2d(double *, __pyx_pybuffernd_new_nodes.rcbuffer->pybuffer.buf, __pyx_t_14, __pyx_pybuffernd_new_nodes.diminfo[0].strides, __pyx_t_15, __pyx_pybuffernd_new_nodes.diminfo[1].strides))));
 
   /* "bezier/_speedup.pyx":660
  *     )
@@ -11848,7 +11848,7 @@ static PyObject *__pyx_pf_6bezier_8_speedup_54evaluate_barycentric(CYTHON_UNUSED
  *         &num_nodes,
  *         &dimension,
  */
-  evaluate_barycentric((&__pyx_v_num_nodes), (&__pyx_v_dimension), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ ((char *) (((double *) __pyx_v_nodes.data) + __pyx_t_12)) ) + __pyx_t_13 * __pyx_v_nodes.strides[1]) )))), (&__pyx_v_degree), (&__pyx_v_lambda1), (&__pyx_v_lambda2), (&__pyx_v_lambda3), (&(*__Pyx_BufPtrFortranContig2d(double *, __pyx_pybuffernd_point.rcbuffer->pybuffer.buf, __pyx_t_14, __pyx_pybuffernd_point.diminfo[0].strides, __pyx_t_15, __pyx_pybuffernd_point.diminfo[1].strides))));
+  BEZ_evaluate_barycentric((&__pyx_v_num_nodes), (&__pyx_v_dimension), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ ((char *) (((double *) __pyx_v_nodes.data) + __pyx_t_12)) ) + __pyx_t_13 * __pyx_v_nodes.strides[1]) )))), (&__pyx_v_degree), (&__pyx_v_lambda1), (&__pyx_v_lambda2), (&__pyx_v_lambda3), (&(*__Pyx_BufPtrFortranContig2d(double *, __pyx_pybuffernd_point.rcbuffer->pybuffer.buf, __pyx_t_14, __pyx_pybuffernd_point.diminfo[0].strides, __pyx_t_15, __pyx_pybuffernd_point.diminfo[1].strides))));
 
   /* "bezier/_speedup.pyx":683
  *     )
@@ -12279,7 +12279,7 @@ static PyObject *__pyx_pf_6bezier_8_speedup_56evaluate_barycentric_multi(CYTHON_
  *         &num_nodes,
  *         &dimension,
  */
-  evaluate_barycentric_multi((&__pyx_v_num_nodes), (&__pyx_v_dimension), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ ((char *) (((double *) __pyx_v_nodes.data) + __pyx_t_11)) ) + __pyx_t_12 * __pyx_v_nodes.strides[1]) )))), (&__pyx_v_degree), (&__pyx_v_num_vals), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ ((char *) (((double *) __pyx_v_param_vals.data) + __pyx_t_13)) ) + __pyx_t_14 * __pyx_v_param_vals.strides[1]) )))), (&(*__Pyx_BufPtrFortranContig2d(double *, __pyx_pybuffernd_evaluated.rcbuffer->pybuffer.buf, __pyx_t_15, __pyx_pybuffernd_evaluated.diminfo[0].strides, __pyx_t_16, __pyx_pybuffernd_evaluated.diminfo[1].strides))));
+  BEZ_evaluate_barycentric_multi((&__pyx_v_num_nodes), (&__pyx_v_dimension), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ ((char *) (((double *) __pyx_v_nodes.data) + __pyx_t_11)) ) + __pyx_t_12 * __pyx_v_nodes.strides[1]) )))), (&__pyx_v_degree), (&__pyx_v_num_vals), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ ((char *) (((double *) __pyx_v_param_vals.data) + __pyx_t_13)) ) + __pyx_t_14 * __pyx_v_param_vals.strides[1]) )))), (&(*__Pyx_BufPtrFortranContig2d(double *, __pyx_pybuffernd_evaluated.rcbuffer->pybuffer.buf, __pyx_t_15, __pyx_pybuffernd_evaluated.diminfo[0].strides, __pyx_t_16, __pyx_pybuffernd_evaluated.diminfo[1].strides))));
 
   /* "bezier/_speedup.pyx":708
  *     )
@@ -12712,7 +12712,7 @@ static PyObject *__pyx_pf_6bezier_8_speedup_58evaluate_cartesian_multi(CYTHON_UN
  *         &num_nodes,
  *         &dimension,
  */
-  evaluate_cartesian_multi((&__pyx_v_num_nodes), (&__pyx_v_dimension), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ ((char *) (((double *) __pyx_v_nodes.data) + __pyx_t_11)) ) + __pyx_t_12 * __pyx_v_nodes.strides[1]) )))), (&__pyx_v_degree), (&__pyx_v_num_vals), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ ((char *) (((double *) __pyx_v_param_vals.data) + __pyx_t_13)) ) + __pyx_t_14 * __pyx_v_param_vals.strides[1]) )))), (&(*__Pyx_BufPtrFortranContig2d(double *, __pyx_pybuffernd_evaluated.rcbuffer->pybuffer.buf, __pyx_t_15, __pyx_pybuffernd_evaluated.diminfo[0].strides, __pyx_t_16, __pyx_pybuffernd_evaluated.diminfo[1].strides))));
+  BEZ_evaluate_cartesian_multi((&__pyx_v_num_nodes), (&__pyx_v_dimension), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ ((char *) (((double *) __pyx_v_nodes.data) + __pyx_t_11)) ) + __pyx_t_12 * __pyx_v_nodes.strides[1]) )))), (&__pyx_v_degree), (&__pyx_v_num_vals), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ ((char *) (((double *) __pyx_v_param_vals.data) + __pyx_t_13)) ) + __pyx_t_14 * __pyx_v_param_vals.strides[1]) )))), (&(*__Pyx_BufPtrFortranContig2d(double *, __pyx_pybuffernd_evaluated.rcbuffer->pybuffer.buf, __pyx_t_15, __pyx_pybuffernd_evaluated.diminfo[0].strides, __pyx_t_16, __pyx_pybuffernd_evaluated.diminfo[1].strides))));
 
   /* "bezier/_speedup.pyx":733
  *     )
@@ -13039,7 +13039,7 @@ static PyObject *__pyx_pf_6bezier_8_speedup_60jacobian_both(CYTHON_UNUSED PyObje
  *         &num_nodes,
  *         &dimension,
  */
-  jacobian_both((&__pyx_v_num_nodes), (&__pyx_v_dimension), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ ((char *) (((double *) __pyx_v_nodes.data) + __pyx_t_11)) ) + __pyx_t_12 * __pyx_v_nodes.strides[1]) )))), (&__pyx_v_degree), (&(*__Pyx_BufPtrFortranContig2d(double *, __pyx_pybuffernd_new_nodes.rcbuffer->pybuffer.buf, __pyx_t_13, __pyx_pybuffernd_new_nodes.diminfo[0].strides, __pyx_t_14, __pyx_pybuffernd_new_nodes.diminfo[1].strides))));
+  BEZ_jacobian_both((&__pyx_v_num_nodes), (&__pyx_v_dimension), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ ((char *) (((double *) __pyx_v_nodes.data) + __pyx_t_11)) ) + __pyx_t_12 * __pyx_v_nodes.strides[1]) )))), (&__pyx_v_degree), (&(*__Pyx_BufPtrFortranContig2d(double *, __pyx_pybuffernd_new_nodes.rcbuffer->pybuffer.buf, __pyx_t_13, __pyx_pybuffernd_new_nodes.diminfo[0].strides, __pyx_t_14, __pyx_pybuffernd_new_nodes.diminfo[1].strides))));
 
   /* "bezier/_speedup.pyx":752
  *     )
@@ -13453,7 +13453,7 @@ static PyObject *__pyx_pf_6bezier_8_speedup_62jacobian_det(CYTHON_UNUSED PyObjec
  *         &num_nodes,
  *         &nodes[0, 0],
  */
-  jacobian_det((&__pyx_v_num_nodes), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ ((char *) (((double *) __pyx_v_nodes.data) + __pyx_t_11)) ) + __pyx_t_12 * __pyx_v_nodes.strides[1]) )))), (&__pyx_v_degree), (&__pyx_v_num_vals), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ ((char *) (((double *) __pyx_v_st_vals.data) + __pyx_t_13)) ) + __pyx_t_14 * __pyx_v_st_vals.strides[1]) )))), (&(*__Pyx_BufPtrFortranContig1d(double *, __pyx_pybuffernd_evaluated.rcbuffer->pybuffer.buf, __pyx_t_15, __pyx_pybuffernd_evaluated.diminfo[0].strides))));
+  BEZ_jacobian_det((&__pyx_v_num_nodes), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ ((char *) (((double *) __pyx_v_nodes.data) + __pyx_t_11)) ) + __pyx_t_12 * __pyx_v_nodes.strides[1]) )))), (&__pyx_v_degree), (&__pyx_v_num_vals), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ ((char *) (((double *) __pyx_v_st_vals.data) + __pyx_t_13)) ) + __pyx_t_14 * __pyx_v_st_vals.strides[1]) )))), (&(*__Pyx_BufPtrFortranContig1d(double *, __pyx_pybuffernd_evaluated.rcbuffer->pybuffer.buf, __pyx_t_15, __pyx_pybuffernd_evaluated.diminfo[0].strides))));
 
   /* "bezier/_speedup.pyx":775
  *     )
@@ -13834,7 +13834,7 @@ static PyObject *__pyx_pf_6bezier_8_speedup_64specialize_surface(CYTHON_UNUSED P
  *         &num_nodes,
  *         &dimension,
  */
-  specialize_surface((&__pyx_v_num_nodes), (&__pyx_v_dimension), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ ((char *) (((double *) __pyx_v_nodes.data) + __pyx_t_12)) ) + __pyx_t_13 * __pyx_v_nodes.strides[1]) )))), (&__pyx_v_degree), (&(*((double *) ( /* dim=0 */ ((char *) (((double *) __pyx_v_weights_a.data) + __pyx_t_14)) )))), (&(*((double *) ( /* dim=0 */ ((char *) (((double *) __pyx_v_weights_b.data) + __pyx_t_15)) )))), (&(*((double *) ( /* dim=0 */ ((char *) (((double *) __pyx_v_weights_c.data) + __pyx_t_16)) )))), (&(*__Pyx_BufPtrFortranContig2d(double *, __pyx_pybuffernd_specialized.rcbuffer->pybuffer.buf, __pyx_t_17, __pyx_pybuffernd_specialized.diminfo[0].strides, __pyx_t_18, __pyx_pybuffernd_specialized.diminfo[1].strides))));
+  BEZ_specialize_surface((&__pyx_v_num_nodes), (&__pyx_v_dimension), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ ((char *) (((double *) __pyx_v_nodes.data) + __pyx_t_12)) ) + __pyx_t_13 * __pyx_v_nodes.strides[1]) )))), (&__pyx_v_degree), (&(*((double *) ( /* dim=0 */ ((char *) (((double *) __pyx_v_weights_a.data) + __pyx_t_14)) )))), (&(*((double *) ( /* dim=0 */ ((char *) (((double *) __pyx_v_weights_b.data) + __pyx_t_15)) )))), (&(*((double *) ( /* dim=0 */ ((char *) (((double *) __pyx_v_weights_c.data) + __pyx_t_16)) )))), (&(*__Pyx_BufPtrFortranContig2d(double *, __pyx_pybuffernd_specialized.rcbuffer->pybuffer.buf, __pyx_t_17, __pyx_pybuffernd_specialized.diminfo[0].strides, __pyx_t_18, __pyx_pybuffernd_specialized.diminfo[1].strides))));
 
   /* "bezier/_speedup.pyx":798
  *     )
@@ -14393,7 +14393,7 @@ static PyObject *__pyx_pf_6bezier_8_speedup_66subdivide_nodes_surface(CYTHON_UNU
  *         &num_nodes,
  *         &dimension,
  */
-  subdivide_nodes_surface((&__pyx_v_num_nodes), (&__pyx_v_dimension), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ ((char *) (((double *) __pyx_v_nodes.data) + __pyx_t_15)) ) + __pyx_t_16 * __pyx_v_nodes.strides[1]) )))), (&__pyx_v_degree), (&(*__Pyx_BufPtrFortranContig2d(double *, __pyx_pybuffernd_nodes_a.rcbuffer->pybuffer.buf, __pyx_t_17, __pyx_pybuffernd_nodes_a.diminfo[0].strides, __pyx_t_18, __pyx_pybuffernd_nodes_a.diminfo[1].strides))), (&(*__Pyx_BufPtrFortranContig2d(double *, __pyx_pybuffernd_nodes_b.rcbuffer->pybuffer.buf, __pyx_t_19, __pyx_pybuffernd_nodes_b.diminfo[0].strides, __pyx_t_20, __pyx_pybuffernd_nodes_b.diminfo[1].strides))), (&(*__Pyx_BufPtrFortranContig2d(double *, __pyx_pybuffernd_nodes_c.rcbuffer->pybuffer.buf, __pyx_t_21, __pyx_pybuffernd_nodes_c.diminfo[0].strides, __pyx_t_22, __pyx_pybuffernd_nodes_c.diminfo[1].strides))), (&(*__Pyx_BufPtrFortranContig2d(double *, __pyx_pybuffernd_nodes_d.rcbuffer->pybuffer.buf, __pyx_t_23, __pyx_pybuffernd_nodes_d.diminfo[0].strides, __pyx_t_24, __pyx_pybuffernd_nodes_d.diminfo[1].strides))));
+  BEZ_subdivide_nodes_surface((&__pyx_v_num_nodes), (&__pyx_v_dimension), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ ((char *) (((double *) __pyx_v_nodes.data) + __pyx_t_15)) ) + __pyx_t_16 * __pyx_v_nodes.strides[1]) )))), (&__pyx_v_degree), (&(*__Pyx_BufPtrFortranContig2d(double *, __pyx_pybuffernd_nodes_a.rcbuffer->pybuffer.buf, __pyx_t_17, __pyx_pybuffernd_nodes_a.diminfo[0].strides, __pyx_t_18, __pyx_pybuffernd_nodes_a.diminfo[1].strides))), (&(*__Pyx_BufPtrFortranContig2d(double *, __pyx_pybuffernd_nodes_b.rcbuffer->pybuffer.buf, __pyx_t_19, __pyx_pybuffernd_nodes_b.diminfo[0].strides, __pyx_t_20, __pyx_pybuffernd_nodes_b.diminfo[1].strides))), (&(*__Pyx_BufPtrFortranContig2d(double *, __pyx_pybuffernd_nodes_c.rcbuffer->pybuffer.buf, __pyx_t_21, __pyx_pybuffernd_nodes_c.diminfo[0].strides, __pyx_t_22, __pyx_pybuffernd_nodes_c.diminfo[1].strides))), (&(*__Pyx_BufPtrFortranContig2d(double *, __pyx_pybuffernd_nodes_d.rcbuffer->pybuffer.buf, __pyx_t_23, __pyx_pybuffernd_nodes_d.diminfo[0].strides, __pyx_t_24, __pyx_pybuffernd_nodes_d.diminfo[1].strides))));
 
   /* "bezier/_speedup.pyx":825
  *     )
@@ -14892,7 +14892,7 @@ static PyObject *__pyx_pf_6bezier_8_speedup_68compute_edge_nodes(CYTHON_UNUSED P
  *         &num_nodes,
  *         &dimension,
  */
-  compute_edge_nodes((&__pyx_v_num_nodes), (&__pyx_v_dimension), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ ((char *) (((double *) __pyx_v_nodes.data) + __pyx_t_14)) ) + __pyx_t_15 * __pyx_v_nodes.strides[1]) )))), (&__pyx_v_degree), (&(*__Pyx_BufPtrFortranContig2d(double *, __pyx_pybuffernd_nodes1.rcbuffer->pybuffer.buf, __pyx_t_16, __pyx_pybuffernd_nodes1.diminfo[0].strides, __pyx_t_17, __pyx_pybuffernd_nodes1.diminfo[1].strides))), (&(*__Pyx_BufPtrFortranContig2d(double *, __pyx_pybuffernd_nodes2.rcbuffer->pybuffer.buf, __pyx_t_18, __pyx_pybuffernd_nodes2.diminfo[0].strides, __pyx_t_19, __pyx_pybuffernd_nodes2.diminfo[1].strides))), (&(*__Pyx_BufPtrFortranContig2d(double *, __pyx_pybuffernd_nodes3.rcbuffer->pybuffer.buf, __pyx_t_20, __pyx_pybuffernd_nodes3.diminfo[0].strides, __pyx_t_21, __pyx_pybuffernd_nodes3.diminfo[1].strides))));
+  BEZ_compute_edge_nodes((&__pyx_v_num_nodes), (&__pyx_v_dimension), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ ((char *) (((double *) __pyx_v_nodes.data) + __pyx_t_14)) ) + __pyx_t_15 * __pyx_v_nodes.strides[1]) )))), (&__pyx_v_degree), (&(*__Pyx_BufPtrFortranContig2d(double *, __pyx_pybuffernd_nodes1.rcbuffer->pybuffer.buf, __pyx_t_16, __pyx_pybuffernd_nodes1.diminfo[0].strides, __pyx_t_17, __pyx_pybuffernd_nodes1.diminfo[1].strides))), (&(*__Pyx_BufPtrFortranContig2d(double *, __pyx_pybuffernd_nodes2.rcbuffer->pybuffer.buf, __pyx_t_18, __pyx_pybuffernd_nodes2.diminfo[0].strides, __pyx_t_19, __pyx_pybuffernd_nodes2.diminfo[1].strides))), (&(*__Pyx_BufPtrFortranContig2d(double *, __pyx_pybuffernd_nodes3.rcbuffer->pybuffer.buf, __pyx_t_20, __pyx_pybuffernd_nodes3.diminfo[0].strides, __pyx_t_21, __pyx_pybuffernd_nodes3.diminfo[1].strides))));
 
   /* "bezier/_speedup.pyx":849
  *     )
@@ -15306,7 +15306,7 @@ static PyObject *__pyx_pf_6bezier_8_speedup_70compute_area(CYTHON_UNUSED PyObjec
  *         &num_edges,
  *         &sizes[0],
  */
-  compute_area((&__pyx_v_num_edges), (&(*((int *) ( /* dim=0 */ ((char *) (((int *) __pyx_v_sizes.data) + __pyx_t_16)) )))), __pyx_v_nodes_pointers, (&__pyx_v_area), (&__pyx_v_unused_not_implemented));
+  BEZ_compute_area((&__pyx_v_num_edges), (&(*((int *) ( /* dim=0 */ ((char *) (((int *) __pyx_v_sizes.data) + __pyx_t_16)) )))), __pyx_v_nodes_pointers, (&__pyx_v_area), (&__pyx_v_unused_not_implemented));
 
   /* "bezier/_speedup.pyx":894
  *     )
@@ -15590,7 +15590,7 @@ static PyObject *__pyx_pf_6bezier_8_speedup_72newton_refine_surface(CYTHON_UNUSE
  *         &num_nodes,
  *         &nodes[0, 0],
  */
-  newton_refine_surface((&__pyx_v_num_nodes), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ ((char *) (((double *) __pyx_v_nodes.data) + __pyx_t_7)) ) + __pyx_t_8 * __pyx_v_nodes.strides[1]) )))), (&__pyx_v_degree), (&__pyx_v_x_val), (&__pyx_v_y_val), (&__pyx_v_s), (&__pyx_v_t), (&__pyx_v_updated_s), (&__pyx_v_updated_t));
+  BEZ_newton_refine_surface((&__pyx_v_num_nodes), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ ((char *) (((double *) __pyx_v_nodes.data) + __pyx_t_7)) ) + __pyx_t_8 * __pyx_v_nodes.strides[1]) )))), (&__pyx_v_degree), (&__pyx_v_x_val), (&__pyx_v_y_val), (&__pyx_v_s), (&__pyx_v_t), (&__pyx_v_updated_s), (&__pyx_v_updated_t));
 
   /* "bezier/_speedup.pyx":923
  *     )
@@ -15849,7 +15849,7 @@ static PyObject *__pyx_pf_6bezier_8_speedup_74locate_point_surface(CYTHON_UNUSED
  *         &num_nodes,
  *         &nodes[0, 0],
  */
-  locate_point_surface((&__pyx_v_num_nodes), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ ((char *) (((double *) __pyx_v_nodes.data) + __pyx_t_7)) ) + __pyx_t_8 * __pyx_v_nodes.strides[1]) )))), (&__pyx_v_degree), (&__pyx_v_x_val), (&__pyx_v_y_val), (&__pyx_v_s_val), (&__pyx_v_t_val));
+  BEZ_locate_point_surface((&__pyx_v_num_nodes), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ ((char *) (((double *) __pyx_v_nodes.data) + __pyx_t_7)) ) + __pyx_t_8 * __pyx_v_nodes.strides[1]) )))), (&__pyx_v_degree), (&__pyx_v_x_val), (&__pyx_v_y_val), (&__pyx_v_s_val), (&__pyx_v_t_val));
 
   /* "bezier/_speedup.pyx":944
  *     )
@@ -17252,7 +17252,7 @@ static PyObject *__pyx_pf_6bezier_8_speedup_80_surface_intersections_success(CYT
  *         &num_nodes,
  *         &dimension,
  */
-  compute_edge_nodes((&__pyx_v_num_nodes), (&__pyx_v_dimension), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ ((char *) (((double *) __pyx_v_nodes1.data) + __pyx_t_20)) ) + __pyx_t_21 * __pyx_v_nodes1.strides[1]) )))), (&__pyx_v_degree1), (&(*__Pyx_BufPtrFortranContig2d(double *, __pyx_pybuffernd_edge_nodes1.rcbuffer->pybuffer.buf, __pyx_t_22, __pyx_pybuffernd_edge_nodes1.diminfo[0].strides, __pyx_t_23, __pyx_pybuffernd_edge_nodes1.diminfo[1].strides))), (&(*__Pyx_BufPtrFortranContig2d(double *, __pyx_pybuffernd_edge_nodes2.rcbuffer->pybuffer.buf, __pyx_t_24, __pyx_pybuffernd_edge_nodes2.diminfo[0].strides, __pyx_t_25, __pyx_pybuffernd_edge_nodes2.diminfo[1].strides))), (&(*__Pyx_BufPtrFortranContig2d(double *, __pyx_pybuffernd_edge_nodes3.rcbuffer->pybuffer.buf, __pyx_t_26, __pyx_pybuffernd_edge_nodes3.diminfo[0].strides, __pyx_t_27, __pyx_pybuffernd_edge_nodes3.diminfo[1].strides))));
+  BEZ_compute_edge_nodes((&__pyx_v_num_nodes), (&__pyx_v_dimension), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ ((char *) (((double *) __pyx_v_nodes1.data) + __pyx_t_20)) ) + __pyx_t_21 * __pyx_v_nodes1.strides[1]) )))), (&__pyx_v_degree1), (&(*__Pyx_BufPtrFortranContig2d(double *, __pyx_pybuffernd_edge_nodes1.rcbuffer->pybuffer.buf, __pyx_t_22, __pyx_pybuffernd_edge_nodes1.diminfo[0].strides, __pyx_t_23, __pyx_pybuffernd_edge_nodes1.diminfo[1].strides))), (&(*__Pyx_BufPtrFortranContig2d(double *, __pyx_pybuffernd_edge_nodes2.rcbuffer->pybuffer.buf, __pyx_t_24, __pyx_pybuffernd_edge_nodes2.diminfo[0].strides, __pyx_t_25, __pyx_pybuffernd_edge_nodes2.diminfo[1].strides))), (&(*__Pyx_BufPtrFortranContig2d(double *, __pyx_pybuffernd_edge_nodes3.rcbuffer->pybuffer.buf, __pyx_t_26, __pyx_pybuffernd_edge_nodes3.diminfo[0].strides, __pyx_t_27, __pyx_pybuffernd_edge_nodes3.diminfo[1].strides))));
 
   /* "bezier/_speedup.pyx":1024
  *     )
@@ -17564,7 +17564,7 @@ static PyObject *__pyx_pf_6bezier_8_speedup_80_surface_intersections_success(CYT
  *         &num_nodes,
  *         &dimension,
  */
-  compute_edge_nodes((&__pyx_v_num_nodes), (&__pyx_v_dimension), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ ((char *) (((double *) __pyx_v_nodes2.data) + __pyx_t_31)) ) + __pyx_t_32 * __pyx_v_nodes2.strides[1]) )))), (&__pyx_v_degree2), (&(*__Pyx_BufPtrFortranContig2d(double *, __pyx_pybuffernd_edge_nodes4.rcbuffer->pybuffer.buf, __pyx_t_33, __pyx_pybuffernd_edge_nodes4.diminfo[0].strides, __pyx_t_34, __pyx_pybuffernd_edge_nodes4.diminfo[1].strides))), (&(*__Pyx_BufPtrFortranContig2d(double *, __pyx_pybuffernd_edge_nodes5.rcbuffer->pybuffer.buf, __pyx_t_35, __pyx_pybuffernd_edge_nodes5.diminfo[0].strides, __pyx_t_36, __pyx_pybuffernd_edge_nodes5.diminfo[1].strides))), (&(*__Pyx_BufPtrFortranContig2d(double *, __pyx_pybuffernd_edge_nodes6.rcbuffer->pybuffer.buf, __pyx_t_37, __pyx_pybuffernd_edge_nodes6.diminfo[0].strides, __pyx_t_38, __pyx_pybuffernd_edge_nodes6.diminfo[1].strides))));
+  BEZ_compute_edge_nodes((&__pyx_v_num_nodes), (&__pyx_v_dimension), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ ((char *) (((double *) __pyx_v_nodes2.data) + __pyx_t_31)) ) + __pyx_t_32 * __pyx_v_nodes2.strides[1]) )))), (&__pyx_v_degree2), (&(*__Pyx_BufPtrFortranContig2d(double *, __pyx_pybuffernd_edge_nodes4.rcbuffer->pybuffer.buf, __pyx_t_33, __pyx_pybuffernd_edge_nodes4.diminfo[0].strides, __pyx_t_34, __pyx_pybuffernd_edge_nodes4.diminfo[1].strides))), (&(*__Pyx_BufPtrFortranContig2d(double *, __pyx_pybuffernd_edge_nodes5.rcbuffer->pybuffer.buf, __pyx_t_35, __pyx_pybuffernd_edge_nodes5.diminfo[0].strides, __pyx_t_36, __pyx_pybuffernd_edge_nodes5.diminfo[1].strides))), (&(*__Pyx_BufPtrFortranContig2d(double *, __pyx_pybuffernd_edge_nodes6.rcbuffer->pybuffer.buf, __pyx_t_37, __pyx_pybuffernd_edge_nodes6.diminfo[0].strides, __pyx_t_38, __pyx_pybuffernd_edge_nodes6.diminfo[1].strides))));
 
   /* "bezier/_speedup.pyx":1039
  *
@@ -18702,7 +18702,7 @@ static PyObject *__pyx_pf_6bezier_8_speedup_84surface_intersections(CYTHON_UNUSE
  *         &num_nodes1,
  *         &nodes1[0, 0],
  */
-  surface_intersections((&__pyx_v_num_nodes1), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ ((char *) (((double *) __pyx_v_nodes1.data) + __pyx_t_8)) ) + __pyx_t_9 * __pyx_v_nodes1.strides[1]) )))), (&__pyx_v_degree1), (&__pyx_v_num_nodes2), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ ((char *) (((double *) __pyx_v_nodes2.data) + __pyx_t_10)) ) + __pyx_t_11 * __pyx_v_nodes2.strides[1]) )))), (&__pyx_v_degree2), (&__pyx_v_segment_ends_size), (&(*((int *) ( /* dim=0 */ ((char *) (((int *) __pyx_v_6bezier_8_speedup_SEGMENT_ENDS_WORKSPACE.data) + __pyx_t_12)) )))), (&__pyx_v_segments_size), (&(*((CurvedPolygonSegment *) ( /* dim=0 */ ((char *) (((CurvedPolygonSegment *) __pyx_v_6bezier_8_speedup_SEGMENTS_WORKSPACE.data) + __pyx_t_13)) )))), (&__pyx_v_num_intersected), (&__pyx_v_contained), (&__pyx_v_status));
+  BEZ_surface_intersections((&__pyx_v_num_nodes1), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ ((char *) (((double *) __pyx_v_nodes1.data) + __pyx_t_8)) ) + __pyx_t_9 * __pyx_v_nodes1.strides[1]) )))), (&__pyx_v_degree1), (&__pyx_v_num_nodes2), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ ((char *) (((double *) __pyx_v_nodes2.data) + __pyx_t_10)) ) + __pyx_t_11 * __pyx_v_nodes2.strides[1]) )))), (&__pyx_v_degree2), (&__pyx_v_segment_ends_size), (&(*((int *) ( /* dim=0 */ ((char *) (((int *) __pyx_v_6bezier_8_speedup_SEGMENT_ENDS_WORKSPACE.data) + __pyx_t_12)) )))), (&__pyx_v_segments_size), (&(*((CurvedPolygonSegment *) ( /* dim=0 */ ((char *) (((CurvedPolygonSegment *) __pyx_v_6bezier_8_speedup_SEGMENTS_WORKSPACE.data) + __pyx_t_13)) )))), (&__pyx_v_num_intersected), (&__pyx_v_contained), (&__pyx_v_status));
 
   /* "bezier/_speedup.pyx":1116
  *     )
@@ -19269,7 +19269,7 @@ static PyObject *__pyx_pf_6bezier_8_speedup_86free_surface_intersections_workspa
  *
  *
  */
-  free_surface_intersections_workspace();
+  BEZ_free_surface_intersections_workspace();
 
   /* "bezier/_speedup.pyx":1156
  *

--- a/src/python/bezier/_surface.pxd
+++ b/src/python/bezier/_surface.pxd
@@ -17,27 +17,37 @@ from libcpp cimport bool as bool_t
 
 
 cdef extern from "bezier/surface.h":
-    void de_casteljau_one_round(int* num_nodes, int* dimension, double* nodes,
+    void de_casteljau_one_round "BEZ_de_casteljau_one_round" (
+        int* num_nodes, int* dimension, double* nodes,
         int* degree, double* lambda1, double* lambda2, double* lambda3,
         double* new_nodes)
-    void evaluate_barycentric(int* num_nodes, int* dimension, double* nodes,
+    void evaluate_barycentric "BEZ_evaluate_barycentric" (
+        int* num_nodes, int* dimension, double* nodes,
         int* degree, double* lambda1, double* lambda2, double* lambda3,
         double* point)
-    void evaluate_barycentric_multi(int* num_nodes, int* dimension, double* nodes,
+    void evaluate_barycentric_multi "BEZ_evaluate_barycentric_multi" (
+        int* num_nodes, int* dimension, double* nodes,
         int* degree, int* num_vals, double* param_vals, double* evaluated)
-    void evaluate_cartesian_multi(int* num_nodes, int* dimension, double* nodes,
+    void evaluate_cartesian_multi "BEZ_evaluate_cartesian_multi" (
+        int* num_nodes, int* dimension, double* nodes,
         int* degree, int* num_vals, double* param_vals, double* evaluated)
-    void jacobian_both(int* num_nodes, int* dimension, double* nodes, int* degree,
+    void jacobian_both "BEZ_jacobian_both" (
+        int* num_nodes, int* dimension, double* nodes, int* degree,
         double* new_nodes)
-    void jacobian_det(int* num_nodes, double* nodes, int* degree, int* num_vals,
+    void jacobian_det "BEZ_jacobian_det" (
+        int* num_nodes, double* nodes, int* degree, int* num_vals,
         double* param_vals, double* evaluated)
-    void specialize_surface(int* num_nodes, int* dimension, double* nodes,
+    void specialize_surface "BEZ_specialize_surface" (
+        int* num_nodes, int* dimension, double* nodes,
         int* degree, double* weights_a, double* weights_b, double* weights_c,
         double* specialized)
-    void subdivide_nodes_surface(int* num_nodes, int* dimension, double* nodes,
+    void subdivide_nodes_surface "BEZ_subdivide_nodes_surface" (
+        int* num_nodes, int* dimension, double* nodes,
         int* degree, double* nodes_a, double* nodes_b, double* nodes_c,
         double* nodes_d)
-    void compute_edge_nodes(int* num_nodes, int* dimension, double* nodes,
+    void compute_edge_nodes "BEZ_compute_edge_nodes" (
+        int* num_nodes, int* dimension, double* nodes,
         int* degree, double* nodes1, double* nodes2, double* nodes3)
-    void compute_area(int* num_edges, int* sizes, double** nodes_pointers,
+    void compute_area "BEZ_compute_area" (
+        int* num_edges, int* sizes, double** nodes_pointers,
         double* area, bool_t* not_implemented)

--- a/src/python/bezier/_surface_intersection.pxd
+++ b/src/python/bezier/_surface_intersection.pxd
@@ -27,13 +27,16 @@ cdef extern from "bezier/surface_intersection.h":
         double end
         int edge_index
 
-    void newton_refine_surface(int* num_nodes, double* nodes, int* degree,
+    void newton_refine_surface "BEZ_newton_refine_surface" (
+        int* num_nodes, double* nodes, int* degree,
         double* x_val, double* y_val, double* s, double* t, double* updated_s,
         double* updated_t)
-    void locate_point_surface(int* num_nodes, double* nodes, int* degree,
+    void locate_point_surface "BEZ_locate_point_surface" (
+        int* num_nodes, double* nodes, int* degree,
         double* x_val, double* y_val, double* s_val, double* t_val)
-    void surface_intersections(int* num_nodes1, double* nodes1, int* degree1,
+    void surface_intersections "BEZ_surface_intersections" (
+        int* num_nodes1, double* nodes1, int* degree1,
         int* num_nodes2, double* nodes2, int* degree2, int* segment_ends_size,
         int* segment_ends, int* segments_size, CurvedPolygonSegment* segments,
         int* num_intersected, SurfaceContained* contained, Status* status)
-    void free_surface_intersections_workspace()
+    void free_surface_intersections_workspace "BEZ_free_surface_intersections_workspace" ()

--- a/src/python/bezier/curve.py
+++ b/src/python/bezier/curve.py
@@ -703,6 +703,9 @@ class Curve(_base.Base):
 
         return _curve_helpers.locate_point(self._nodes, point)
 
+    # Return type doc appears missing to Pylint because of the use of the
+    # :class:`sympy.Matrix ...` aliases.
+    # pylint: disable=missing-return-type-doc
     def to_symbolic(self):
         """Convert to a SymPy matrix representing :math:`B(s)`.
 
@@ -763,3 +766,5 @@ class Curve(_base.Base):
             )
 
         return _symbolic.implicitize_curve(self._nodes, self._degree)
+
+    # pylint: enable=missing-return-type-doc

--- a/src/python/bezier/surface.py
+++ b/src/python/bezier/surface.py
@@ -1147,6 +1147,9 @@ class Surface(_base.Base):
         new_nodes /= denominator
         return Surface(new_nodes, self._degree + 1, copy=False, verify=False)
 
+    # Return type doc appears missing to Pylint because of the use of the
+    # :class:`sympy.Matrix ...` aliases.
+    # pylint: disable=missing-return-type-doc
     def to_symbolic(self):
         """Convert to a SymPy matrix representing :math:`B(s, t)`.
 
@@ -1211,6 +1214,8 @@ class Surface(_base.Base):
             )
 
         return _symbolic.implicitize_surface(self._nodes, self._degree)
+
+    # pylint: enable=missing-return-type-doc
 
 
 def _make_intersection(edge_info, all_edge_nodes):


### PR DESCRIPTION
Fixes #166.