### PR TITLE
Use `const` pointers for arguments of type `[in]` headers.

### DIFF
--- a/docs/abi/curve.rst
+++ b/docs/abi/curve.rst
@@ -14,9 +14,9 @@ B |eacute| zier `curve`_.
 Procedures
 **********
 
-.. c:function:: void BEZ_compute_length(int *num_nodes, \
-                                        int *dimension, \
-                                        double *nodes, \
+.. c:function:: void BEZ_compute_length(const int *num_nodes, \
+                                        const int *dimension, \
+                                        const double *nodes, \
                                         double *length, \
                                         int *error_val)
 
@@ -26,16 +26,19 @@ Procedures
 
       \ell = \int_0^1 \left\lVert B'(s) \right\rVert \, ds.
 
-   :param int* num_nodes:
+   :param num_nodes:
       **[Input]** The number of control points :math:`N` of a
       B |eacute| zier curve.
-   :param int* dimension:
+   :type num_nodes: const int*
+   :param dimension:
       **[Input]** The dimension :math:`D` such that the curve lies in
       :math:`\mathbf{R}^D`.
-   :param double* nodes:
+   :type dimension: const int*
+   :param nodes:
       **[Input]** The actual control points of the curve as a
       :math:`D \times N` array. This should be laid out in Fortran order,
       with :math:`D N` total values.
+   :type nodes: const double*
    :param double* length:
       **[Output]** The computed length :math:`\ell`.
    :param int* error_val:
@@ -47,9 +50,9 @@ Procedures
    .. code-block:: c
 
       void
-      BEZ_compute_length(int *num_nodes,
-                         int *dimension,
-                         double *nodes,
+      BEZ_compute_length(const int *num_nodes,
+                         const int *dimension,
+                         const double *nodes,
                          double *length,
                          int *error_val);
 
@@ -76,9 +79,9 @@ Procedures
       Length: 5.000000
       Error value: 0
 
-.. c:function:: void BEZ_elevate_nodes_curve(int *num_nodes, \
-                                             int *dimension, \
-                                             double *nodes, \
+.. c:function:: void BEZ_elevate_nodes_curve(const int *num_nodes, \
+                                             const int *dimension, \
+                                             const double *nodes, \
                                              double *elevated)
 
    Degree-elevate a B |eacute| zier curve. Does so by producing
@@ -86,16 +89,19 @@ Procedures
 
    See :meth:`.Curve.elevate` for more details.
 
-   :param int* num_nodes:
+   :param num_nodes:
       **[Input]** The number of control points :math:`N` of a
       B |eacute| zier curve.
-   :param int* dimension:
+   :type num_nodes: const int*
+   :param dimension:
       **[Input]** The dimension :math:`D` such that the curve lies in
       :math:`\mathbf{R}^D`.
-   :param double* nodes:
+   :type dimension: const int*
+   :param nodes:
       **[Input]** The actual control points of the curve as a
       :math:`D \times N` array. This should be laid out in Fortran order,
       with :math:`D N` total values.
+   :type nodes: const double*
    :param double* elevated:
       **[Output]** The control points of the degree-elevated curve as a
       :math:`D \times (N + 1)` array, laid out in Fortran order.
@@ -105,9 +111,9 @@ Procedures
    .. code-block:: c
 
       void
-      BEZ_elevate_nodes_curve(int *num_nodes,
-                              int *dimension,
-                              double *nodes,
+      BEZ_elevate_nodes_curve(const int *num_nodes,
+                              const int *dimension,
+                              const double *nodes,
                               double *elevated);
 
    **Example:**
@@ -145,12 +151,12 @@ Procedures
    .. image:: ../images/curve_elevate.png
       :align: center
 
-.. c:function:: void BEZ_evaluate_curve_barycentric(int *num_nodes, \
-                                                    int *dimension, \
-                                                    double *nodes, \
-                                                    int *num_vals, \
-                                                    double *lambda1, \
-                                                    double *lambda2, \
+.. c:function:: void BEZ_evaluate_curve_barycentric(const int *num_nodes, \
+                                                    const int *dimension, \
+                                                    const double *nodes, \
+                                                    const int *num_vals, \
+                                                    const double *lambda1, \
+                                                    const double *lambda2, \
                                                     double *evaluated)
 
    For a B |eacute| zier curve with control points :math:`p_0, \ldots, p_d`,
@@ -164,25 +170,31 @@ Procedures
    The typical case is barycentric, i.e. :math:`\lambda_1 + \lambda_2 = 1`, but
    this is not required.
 
-   :param int* num_nodes:
+   :param num_nodes:
       **[Input]** The number of control points :math:`N` of a
       B |eacute| zier curve.
-   :param int* dimension:
+   :type num_nodes: const int*
+   :param dimension:
       **[Input]** The dimension :math:`D` such that the curve lies in
       :math:`\mathbf{R}^D`.
-   :param double* nodes:
+   :type dimension: const int*
+   :param nodes:
       **[Input]** The actual control points of the curve as a
       :math:`D \times N` array. This should be laid out in Fortran order,
       with :math:`D N` total values.
-   :param int* num_vals:
+   :type nodes: const double*
+   :param num_vals:
       **[Input]** The number of values :math:`k` where the quantity will be
       evaluated.
-   :param double* lambda1:
+   :type num_vals: const int*
+   :param lambda1:
       **[Input]** An array of :math:`k` values used for the first parameter
       :math:`\lambda_1`.
-   :param double* lambda2:
+   :type lambda1: const double*
+   :param lambda2:
       **[Input]** An array of :math:`k` values used for the second parameter
       :math:`\lambda_2`.
+   :type lambda2: const double*
    :param double* evaluated:
       **[Output]** The evaluated quantites as a :math:`D \times k` array, laid
       out in Fortran order. Column :math:`j` of ``evaluated`` will contain
@@ -193,12 +205,12 @@ Procedures
    .. code-block:: c
 
       void
-      BEZ_evaluate_curve_barycentric(int *num_nodes,
-                                     int *dimension,
-                                     double *nodes,
-                                     int *num_vals,
-                                     double *lambda1,
-                                     double *lambda2,
+      BEZ_evaluate_curve_barycentric(const int *num_nodes,
+                                     const int *dimension,
+                                     const double *nodes,
+                                     const int *num_vals,
+                                     const double *lambda1,
+                                     const double *lambda2,
                                      double *evaluated);
 
    **Example:**
@@ -243,28 +255,32 @@ Procedures
       2.437500, 0.687500, 0.750000, 1.187500
       2.125000, 0.687500, 0.750000, 1.687500
 
-.. c:function:: void BEZ_evaluate_hodograph(double *s, \
-                                            int *num_nodes, \
-                                            int *dimension, \
-                                            double *nodes, \
+.. c:function:: void BEZ_evaluate_hodograph(const double *s, \
+                                            const int *num_nodes, \
+                                            const int *dimension, \
+                                            const double *nodes, \
                                             double *hodograph)
 
    Evaluates the hodograph (or derivative) of a B |eacute| zier curve
    function :math:`B'(s)`.
 
-   :param double* s:
+   :param s:
       **[Input]** The parameter :math:`s` where the hodograph is being
       computed.
-   :param int* num_nodes:
+   :type s: const double*
+   :param num_nodes:
       **[Input]** The number of control points :math:`N` of a
       B |eacute| zier curve.
-   :param int* dimension:
+   :type num_nodes: const int*
+   :param dimension:
       **[Input]** The dimension :math:`D` such that the curve lies in
       :math:`\mathbf{R}^D`.
-   :param double* nodes:
+   :type dimension: const int*
+   :param nodes:
       **[Input]** The actual control points of the curve as a
       :math:`D \times N` array. This should be laid out in Fortran order,
       with :math:`D N` total values.
+   :type nodes: const double*
    :param double* hodograph:
       **[Output]** The hodograph :math:`B'(s)` as a :math:`D \times 1` array.
 
@@ -273,10 +289,10 @@ Procedures
    .. code-block:: c
 
       void
-      BEZ_evaluate_hodograph(double *s,
-                             int *num_nodes,
-                             int *dimension,
-                             double *nodes,
+      BEZ_evaluate_hodograph(const double *s,
+                             const int *num_nodes,
+                             const int *dimension,
+                             const double *nodes,
                              double *hodograph);
 
    **Example:**
@@ -309,31 +325,36 @@ Procedures
       0.656250
       1.687500
 
-.. c:function:: void BEZ_evaluate_multi(int *num_nodes, \
-                                        int *dimension, \
-                                        double *nodes, \
-                                        int *num_vals, \
-                                        double *s_vals, \
+.. c:function:: void BEZ_evaluate_multi(const int *num_nodes, \
+                                        const int *dimension, \
+                                        const double *nodes, \
+                                        const int *num_vals, \
+                                        const double *s_vals, \
                                         double *evaluated)
 
    Evaluate a B |eacute| zier curve function :math:`B(s_j)` at
    multiple values :math:`\left\{s_j\right\}_j`.
 
-   :param int* num_nodes:
+   :param num_nodes:
       **[Input]** The number of control points :math:`N` of a
       B |eacute| zier curve.
-   :param int* dimension:
+   :type num_nodes: const int*
+   :param dimension:
       **[Input]** The dimension :math:`D` such that the curve lies in
       :math:`\mathbf{R}^D`.
-   :param double* nodes:
+   :type dimension: const int*
+   :param nodes:
       **[Input]** The actual control points of the curve as a
       :math:`D \times N` array. This should be laid out in Fortran order,
       with :math:`D N` total values.
-   :param int* num_vals:
+   :type nodes: const double*
+   :param num_vals:
       **[Input]** The number of values :math:`k` where the :math:`B(s)` will be
       evaluated.
-   :param double* s_vals:
+   :type num_vals: const int*
+   :param s_vals:
       **[Input]** An array of :math:`k` values :math:`s_j`.
+   :type s_vals: const double*
    :param double* evaluated:
       **[Output]** The evaluated points as a :math:`D \times k` array, laid
       out in Fortran order. Column :math:`j` of ``evaluated`` will contain
@@ -344,11 +365,11 @@ Procedures
    .. code-block:: c
 
       void
-      BEZ_evaluate_multi(int *num_nodes,
-                         int *dimension,
-                         double *nodes,
-                         int *num_vals,
-                         double *s_vals,
+      BEZ_evaluate_multi(const int *num_nodes,
+                         const int *dimension,
+                         const double *nodes,
+                         const int *num_vals,
+                         const double *s_vals,
                          double *evaluated);
 
    **Example:**
@@ -383,10 +404,10 @@ Procedures
       1.000000, 1.500000, 2.000000
       0.000000, 0.500000, 1.000000
 
-.. c:function:: void BEZ_full_reduce(int *num_nodes, \
-                                     int *dimension, \
-                                     double *nodes, \
-                                     int *num_reduced_nodes, \
+.. c:function:: void BEZ_full_reduce(const int *num_nodes, \
+                                     const int *dimension, \
+                                     const double *nodes, \
+                                     const int *num_reduced_nodes, \
                                      double *reduced, \
                                      bool *not_implemented)
 
@@ -394,19 +415,23 @@ Procedures
    :c:func:`BEZ_reduce_pseudo_inverse` continually until the degree of
    the curve can no longer be reduced.
 
-   :param int* num_nodes:
+   :param num_nodes:
       **[Input]** The number of control points :math:`N` of a
       B |eacute| zier curve.
-   :param int* dimension:
+   :type num_nodes: const int*
+   :param dimension:
       **[Input]** The dimension :math:`D` such that the curve lies in
       :math:`\mathbf{R}^D`.
-   :param double* nodes:
+   :type dimension: const int*
+   :param nodes:
       **[Input]** The actual control points of the curve as a
       :math:`D \times N` array. This should be laid out in Fortran order,
       with :math:`D N` total values.
-   :param int* num_reduced_nodes:
+   :type nodes: const double*
+   :param num_reduced_nodes:
       **[Output]** The number of control points :math:`M` of the fully reduced
       curve.
+   :type num_reduced_nodes: const int*
    :param double* reduced:
       **[Output]** The control points of the fully reduced curve as a
       :math:`D \times N` array. The first :math:`M` columns will contain the
@@ -423,10 +448,10 @@ Procedures
    .. code-block:: c
 
       void
-      BEZ_full_reduce(int *num_nodes,
-                      int *dimension,
-                      double *nodes,
-                      int *num_reduced_nodes,
+      BEZ_full_reduce(const int *num_nodes,
+                      const int *dimension,
+                      const double *nodes,
+                      const int *num_reduced_nodes,
                       double *reduced,
                       bool *not_implemented);
 
@@ -461,10 +486,10 @@ Procedures
       3.000000, 5.000000
       Not implemented: FALSE
 
-.. c:function:: void BEZ_get_curvature(int *num_nodes, \
-                                       double *nodes, \
-                                       double *tangent_vec, \
-                                       double *s, \
+.. c:function:: void BEZ_get_curvature(const int *num_nodes, \
+                                       const double *nodes, \
+                                       const double *tangent_vec, \
+                                       const double *s, \
                                        double *curvature)
 
    Get the signed curvature of a B |eacute| zier curve at a point. See
@@ -476,20 +501,24 @@ Procedures
       in :math:`\mathbf{R}^2`). An equivalent notion of curvature exists for
       space curves, but support for that is not implemented here.
 
-   :param int* num_nodes:
+   :param num_nodes:
       **[Input]** The number of control points :math:`N` of a
       B |eacute| zier curve.
-   :param double* nodes:
+   :type num_nodes: const int*
+   :param nodes:
       **[Input]** The actual control points of the curve as a
       :math:`2 \times N` array. This should be laid out in Fortran order,
       with :math:`2 N` total values.
-   :param double* tangent_vec:
+   :type nodes: const double*
+   :param tangent_vec:
       **[Input]** The hodograph :math:`B'(s)` as a :math:`2 \times 1` array.
       Note that this could be computed once :math:`s` and :math:`B` are known,
       but this allows the caller to re-use an already computed tangent vector.
-   :param double* s:
+   :type tangent_vec: const double*
+   :param s:
       **[Input]** The parameter :math:`s` where the curvature is being
       computed.
+   :type s: const double*
    :param double* curvature:
       **[Output]** The signed curvature :math:`\kappa`.
 
@@ -498,10 +527,10 @@ Procedures
    .. code-block:: c
 
       void
-      BEZ_get_curvature(int *num_nodes,
-                        double *nodes,
-                        double *tangent_vec,
-                        double *s,
+      BEZ_get_curvature(const int *num_nodes,
+                        const double *nodes,
+                        const double *tangent_vec,
+                        const double *s,
                         double *curvature);
 
    **Example:**
@@ -526,10 +555,10 @@ Procedures
       $ ./example
       Curvature: -12.000000
 
-.. c:function:: void BEZ_locate_point_curve(int *num_nodes, \
-                                            int *dimension, \
-                                            double *nodes, \
-                                            double *point, \
+.. c:function:: void BEZ_locate_point_curve(const int *num_nodes, \
+                                            const int *dimension, \
+                                            const double *nodes, \
+                                            const double *point, \
                                             double *s_approx)
 
    This solves the inverse problem :math:`B(s) = p` (if it can be
@@ -537,18 +566,22 @@ Procedures
    sufficiently small, then using Newton's method to narrow in on the
    pre-image of the point.
 
-   :param int* num_nodes:
+   :param num_nodes:
       **[Input]** The number of control points :math:`N` of a
       B |eacute| zier curve.
-   :param int* dimension:
+   :type num_nodes: const int*
+   :param dimension:
       **[Input]** The dimension :math:`D` such that the curve lies in
       :math:`\mathbf{R}^D`.
-   :param double* nodes:
+   :type dimension: const int*
+   :param nodes:
       **[Input]** The actual control points of the curve as a
       :math:`D \times N` array. This should be laid out in Fortran order,
       with :math:`D N` total values.
-   :param double* point:
+   :type nodes: const double*
+   :param point:
       **[Input]** The point :math:`p` as a :math:`D \times 1` array.
+   :type point: const double*
    :param double* s_approx:
       **[Output]** The parameter :math:`s` of the solution. If
       :math:`p` can't be located on the curve, then ``s_approx = -1.0``.
@@ -561,10 +594,10 @@ Procedures
    .. code-block:: c
 
       void
-      BEZ_locate_point_curve(int *num_nodes,
-                             int *dimension,
-                             double *nodes,
-                             double *point,
+      BEZ_locate_point_curve(const int *num_nodes,
+                             const int *dimension,
+                             const double *nodes,
+                             const double *point,
                              double *s_approx);
 
    **Example:**
@@ -610,11 +643,11 @@ Procedures
    .. image:: ../images/curve_locate.png
       :align: center
 
-.. c:function:: void BEZ_newton_refine_curve(int *num_nodes, \
-                                             int *dimension, \
-                                             double *nodes, \
-                                             double *point, \
-                                             double *s, \
+.. c:function:: void BEZ_newton_refine_curve(const int *num_nodes, \
+                                             const int *dimension, \
+                                             const double *nodes, \
+                                             const double *point, \
+                                             const double *s, \
                                              double *updated_s)
 
    This refines a solution to :math:`B(s) = p` using Newton's
@@ -626,21 +659,26 @@ Procedures
       s_{n + 1} = s_n - \frac{B'(s_n)^T \left[B(s_n) - p\right]}{
           B'(s_n)^T B'(s_n)}.
 
-   :param int* num_nodes:
+   :param num_nodes:
       **[Input]** The number of control points :math:`N` of a
       B |eacute| zier curve.
-   :param int* dimension:
+   :type num_nodes: const int*
+   :param dimension:
       **[Input]** The dimension :math:`D` such that the curve lies in
       :math:`\mathbf{R}^D`.
-   :param double* nodes:
+   :type dimension: const int*
+   :param nodes:
       **[Input]** The actual control points of the curve as a
       :math:`D \times N` array. This should be laid out in Fortran order,
       with :math:`D N` total values.
-   :param double* point:
+   :type nodes: const double*
+   :param point:
       **[Input]** The point :math:`p` as a :math:`D \times 1` array.
-   :param double* s:
+   :type point: const double*
+   :param s:
       **[Input]** The parameter :math:`s_n` of the current approximation
       of a solution.
+   :type s: const double*
    :param double* updated_s:
       **[Output]** The parameter :math:`s_{n + 1}` of the updated
       approximation.
@@ -650,11 +688,11 @@ Procedures
    .. code-block:: c
 
       void
-      BEZ_newton_refine_curve(int *num_nodes,
-                              int *dimension,
-                              double *nodes,
-                              double *point,
-                              double *s,
+      BEZ_newton_refine_curve(const int *num_nodes,
+                              const int *dimension,
+                              const double *nodes,
+                              const double *point,
+                              const double *s,
                               double *updated_s);
 
    **Example:**
@@ -689,9 +727,9 @@ Procedures
    .. image:: ../images/newton_refine_curve.png
       :align: center
 
-.. c:function:: void BEZ_reduce_pseudo_inverse(int *num_nodes, \
-                                               int *dimension, \
-                                               double *nodes, \
+.. c:function:: void BEZ_reduce_pseudo_inverse(const int *num_nodes, \
+                                               const int *dimension, \
+                                               const double *nodes, \
                                                double *reduced, \
                                                bool *not_implemented)
 
@@ -701,16 +739,19 @@ Procedures
    inverse can be found, then this will produce the "best" answer in
    the least squares sense.
 
-   :param int* num_nodes:
+   :param num_nodes:
       **[Input]** The number of control points :math:`N` of a
       B |eacute| zier curve.
-   :param int* dimension:
+   :type num_nodes: const int*
+   :param dimension:
       **[Input]** The dimension :math:`D` such that the curve lies in
       :math:`\mathbf{R}^D`.
-   :param double* nodes:
+   :type dimension: const int*
+   :param nodes:
       **[Input]** The actual control points of the curve as a
       :math:`D \times N` array. This should be laid out in Fortran order,
       with :math:`D N` total values.
+   :type nodes: const double*
    :param double* reduced:
       **[Output]** The control points of the degree-(pseudo)reduced curve
       :math:`D \times (N - 1)` array, laid out in Fortran order.
@@ -724,9 +765,9 @@ Procedures
    .. code-block:: c
 
       void
-      BEZ_reduce_pseudo_inverse(int *num_nodes,
-                                int *dimension,
-                                double *nodes,
+      BEZ_reduce_pseudo_inverse(const int *num_nodes,
+                                const int *dimension,
+                                const double *nodes,
                                 double *reduced,
                                 bool *not_implemented);
 
@@ -765,31 +806,36 @@ Procedures
    .. image:: ../images/curve_reduce.png
       :align: center
 
-.. c:function:: void BEZ_specialize_curve(int *num_nodes, \
-                                          int *dimension, \
-                                          double *nodes, \
-                                          double *start, \
-                                          double *end, \
+.. c:function:: void BEZ_specialize_curve(const int *num_nodes, \
+                                          const int *dimension, \
+                                          const double *nodes, \
+                                          const double *start, \
+                                          const double *end, \
                                           double *new_nodes)
 
    Specialize a B |eacute| zier curve to an interval
    :math:`\left[a, b\right]`. This produces the control points
    for the curve given by :math:`B\left(a + (b - a) s\right)`.
 
-   :param int* num_nodes:
+   :param num_nodes:
       **[Input]** The number of control points :math:`N` of a
       B |eacute| zier curve.
-   :param int* dimension:
+   :type num_nodes: const int*
+   :param dimension:
       **[Input]** The dimension :math:`D` such that the curve lies in
       :math:`\mathbf{R}^D`.
-   :param double* nodes:
+   :type dimension: const int*
+   :param nodes:
       **[Input]** The actual control points of the curve as a
       :math:`D \times N` array. This should be laid out in Fortran order,
       with :math:`D N` total values.
-   :param double* start:
+   :type nodes: const double*
+   :param start:
       **[Input]** The start :math:`a` of the specialized interval.
-   :param double* end:
+   :type start: const double*
+   :param end:
       **[Input]** The end :math:`b` of the specialized interval.
+   :type end: const double*
    :param double* new_nodes:
       **[Output]** The control points of the specialized curve, as a
       :math:`D \times N` array, laid out in Fortran order.
@@ -799,11 +845,11 @@ Procedures
    .. code-block:: c
 
       void
-      BEZ_specialize_curve(int *num_nodes,
-                           int *dimension,
-                           double *nodes,
-                           double *start,
-                           double *end,
+      BEZ_specialize_curve(const int *num_nodes,
+                           const int *dimension,
+                           const double *nodes,
+                           const double *start,
+                           const double *end,
                            double *new_nodes);
 
    **Example:**
@@ -844,9 +890,9 @@ Procedures
    .. image:: ../images/curve_specialize.png
       :align: center
 
-.. c:function:: void BEZ_subdivide_nodes_curve(int *num_nodes, \
-                                               int *dimension, \
-                                               double *nodes, \
+.. c:function:: void BEZ_subdivide_nodes_curve(const int *num_nodes, \
+                                               const int *dimension, \
+                                               const double *nodes, \
                                                double *left_nodes, \
                                                double *right_nodes)
 
@@ -854,16 +900,19 @@ Procedures
    :math:`B\left(\left[0, \frac{1}{2}\right]\right)` and
    :math:`B\left(\left[\frac{1}{2}, 1\right]\right)`.
 
-   :param int* num_nodes:
+   :param num_nodes:
       **[Input]** The number of control points :math:`N` of a
       B |eacute| zier curve.
-   :param int* dimension:
+   :type num_nodes: const int*
+   :param dimension:
       **[Input]** The dimension :math:`D` such that the curve lies in
       :math:`\mathbf{R}^D`.
-   :param double* nodes:
+   :type dimension: const int*
+   :param nodes:
       **[Input]** The actual control points of the curve as a
       :math:`D \times N` array. This should be laid out in Fortran order,
       with :math:`D N` total values.
+   :type nodes: const double*
    :param double* left_nodes:
       **[Output]** The control points of the left half curve
       :math:`B\left(\left[0, \frac{1}{2}\right]\right)` as a
@@ -878,9 +927,9 @@ Procedures
    .. code-block:: c
 
       void
-      BEZ_subdivide_nodes_curve(int *num_nodes,
-                                int *dimension,
-                                double *nodes,
+      BEZ_subdivide_nodes_curve(const int *num_nodes,
+                                const int *dimension,
+                                const double *nodes,
                                 double *left_nodes,
                                 double *right_nodes);
 

--- a/docs/abi/curve_intersection.rst
+++ b/docs/abi/curve_intersection.rst
@@ -12,28 +12,32 @@ between two B |eacute| zier curves in :math:`\mathbf{R}^2`.
 Procedures
 **********
 
-.. c:function:: void BEZ_bbox_intersect(int *num_nodes1, \
-                                        double *nodes1, \
-                                        int *num_nodes2, \
-                                        double *nodes2, \
+.. c:function:: void BEZ_bbox_intersect(const int *num_nodes1, \
+                                        const double *nodes1, \
+                                        const int *num_nodes2, \
+                                        const double *nodes2, \
                                         BoxIntersectionType *enum_)
 
    Determine how the bounding boxes of two B |eacute| zier curves intersect.
 
-   :param int* num_nodes1:
+   :param num_nodes1:
       **[Input]** The number of control points :math:`N_1` of the first
       B |eacute| zier curve.
-   :param double* nodes1:
+   :type num_nodes1: const int*
+   :param nodes1:
       **[Input]** The actual control points of the first curve as a
       :math:`2 \times N_1` array. This should be laid out in Fortran order,
       with :math:`2 N_1` total values.
-   :param int* num_nodes2:
+   :type nodes1: const double*
+   :param num_nodes2:
       **[Input]** The number of control points :math:`N_2` of the second
       B |eacute| zier curve.
-   :param double* nodes2:
+   :type num_nodes2: const int*
+   :param nodes2:
       **[Input]** The actual control points of the second curve as a
       :math:`2 \times N_2` array. This should be laid out in Fortran order,
       with :math:`2 N_2` total values.
+   :type nodes2: const double*
    :param BoxIntersectionType* enum_:
       **[Output]** The type of intersection between the bounding boxes of the
       two curves.
@@ -43,17 +47,17 @@ Procedures
    .. code-block:: c
 
       void
-      BEZ_bbox_intersect(int *num_nodes1,
-                         double *nodes1,
-                         int *num_nodes2,
-                         double *nodes2,
+      BEZ_bbox_intersect(const int *num_nodes1,
+                         const double *nodes1,
+                         const int *num_nodes2,
+                         const double *nodes2,
                          BoxIntersectionType *enum_);
 
-.. c:function:: void BEZ_curve_intersections(int *num_nodes_first, \
-                                             double *nodes_first, \
-                                             int *num_nodes_second, \
-                                             double *nodes_second, \
-                                             int *intersections_size, \
+.. c:function:: void BEZ_curve_intersections(const int *num_nodes_first, \
+                                             const double *nodes_first, \
+                                             const int *num_nodes_second, \
+                                             const double *nodes_second, \
+                                             const int *intersections_size, \
                                              double *intersections, \
                                              int *num_intersections, \
                                              bool *coincident, \
@@ -82,25 +86,30 @@ Procedures
       Failed invocations can be avoided altogether if B |eacute| zout's
       theorem is used to determine the maximum number of intersections.
 
-   :param int* num_nodes_first:
+   :param num_nodes_first:
       **[Input]** The number of control points :math:`N_1` of the first
       B |eacute| zier curve.
-   :param double* nodes_first:
+   :type num_nodes_first: const int*
+   :param nodes_first:
       **[Input]** The actual control points of the first curve as a
       :math:`2 \times N_1` array. This should be laid out in Fortran order,
       with :math:`2 N_1` total values.
-   :param int* num_nodes_second:
+   :type nodes_first: const double*
+   :param num_nodes_second:
       **[Input]** The number of control points :math:`N_2` of the second
       B |eacute| zier curve.
-   :param double* nodes_second:
+   :type num_nodes_second: const int*
+   :param nodes_second:
       **[Input]** The actual control points of the second curve as a
       :math:`2 \times N_2` array. This should be laid out in Fortran order,
       with :math:`2 N_2` total values.
-   :param int* intersections_size:
+   :type nodes_second: const double*
+   :param intersections_size:
       **[Input]** The size :math:`S` of ``intersections``, which must be
       pre-allocated by the caller. By B |eacute| zout's theorem, a hard upper
       bound is :math:`S \leq (N_1 - 1)(N_2 - 2)` (since the degree of each
       curve is one less than the number of control points).
+   :type intersections_size: const int*
    :param int* intersections:
       **[Output]** The pairs of intersection points, as a :math:`2 \times S`
       array laid out in Fortran order. The first ``num_intersections``
@@ -133,22 +142,22 @@ Procedures
    .. code-block:: c
 
       void
-      BEZ_curve_intersections(int *num_nodes_first,
-                              double *nodes_first,
-                              int *num_nodes_second,
-                              double *nodes_second,
-                              int *intersections_size,
+      BEZ_curve_intersections(const int *num_nodes_first,
+                              const double *nodes_first,
+                              const int *num_nodes_second,
+                              const double *nodes_second,
+                              const int *intersections_size,
                               double *intersections,
                               int *num_intersections,
                               bool *coincident,
                               Status *status);
 
-.. c:function:: void BEZ_newton_refine_curve_intersect(double *s, \
-                                                       int *num_nodes1, \
-                                                       double *nodes1, \
-                                                       double *t, \
-                                                       int *num_nodes2, \
-                                                       double *nodes2, \
+.. c:function:: void BEZ_newton_refine_curve_intersect(const double *s, \
+                                                       const int *num_nodes1, \
+                                                       const double *nodes1, \
+                                                       const double *t, \
+                                                       const int *num_nodes2, \
+                                                       const double *nodes2, \
                                                        double *new_s, \
                                                        double *new_t, \
                                                        Status *status)
@@ -163,26 +172,32 @@ Procedures
       \left[\begin{array}{c} s_n \\ t_n \end{array}\right] -
       DF(s_n, t_n)^{-1} F(s_n, t_n).
 
-   :param double* s:
+   :param s:
       **[Input]** The first parameter :math:`s_n` of the current approximation
       of a solution.
-   :param int* num_nodes1:
+   :type s: const double*
+   :param num_nodes1:
       **[Input]** The number of control points :math:`N_1` of the first
       B |eacute| zier curve.
-   :param double* nodes1:
+   :type num_nodes1: const int*
+   :param nodes1:
       **[Input]** The actual control points of the first curve as a
       :math:`2 \times N_1` array. This should be laid out in Fortran order,
       with :math:`2 N_1` total values.
-   :param double* t:
+   :type nodes1: const double*
+   :param t:
       **[Input]** The second parameter :math:`t_n` of the current approximation
       of a solution.
-   :param int* num_nodes2:
+   :type t: const double*
+   :param num_nodes2:
       **[Input]** The number of control points :math:`N_2` of the second
       B |eacute| zier curve.
-   :param double* nodes2:
+   :type num_nodes2: const int*
+   :param nodes2:
       **[Input]** The actual control points of the second curve as a
       :math:`2 \times N_2` array. This should be laid out in Fortran order,
       with :math:`2 N_2` total values.
+   :type nodes2: const double*
    :param double* new_s:
       **[Output]** The first parameter :math:`s_{n + 1}` of the updated
       approximation.
@@ -201,12 +216,12 @@ Procedures
    .. code-block:: c
 
       void
-      BEZ_newton_refine_curve_intersect(double *s,
-                                        int *num_nodes1,
-                                        double *nodes1,
-                                        double *t,
-                                        int *num_nodes2,
-                                        double *nodes2,
+      BEZ_newton_refine_curve_intersect(const double *s,
+                                        const int *num_nodes1,
+                                        const double *nodes1,
+                                        const double *t,
+                                        const int *num_nodes2,
+                                        const double *nodes2,
                                         double *new_s,
                                         double *new_t,
                                         Status *status);

--- a/docs/abi/helpers.rst
+++ b/docs/abi/helpers.rst
@@ -9,8 +9,8 @@ with various geometric computations.
 Procedures
 **********
 
-.. c:function:: void BEZ_bbox(int *num_nodes, \
-                              double *nodes, \
+.. c:function:: void BEZ_bbox(const int *num_nodes, \
+                              const double *nodes, \
                               double *left, \
                               double *right, \
                               double *bottom, \
@@ -20,11 +20,13 @@ Procedures
    :math:`\left[m_x, M_x\right] \times \left[m_y, M_y\right]`
    for a set of points in :math:`\mathbf{R}^2`.
 
-   :param int* num_nodes:
+   :param num_nodes:
       **[Input]** The number of nodes :math:`N` we are bounding.
-   :param double* nodes:
+   :type num_nodes: const int*
+   :param nodes:
       **[Input]** The actual nodes as a :math:`2 \times N` array. This should
       be laid out in Fortran order, with :math:`2 N` total values.
+   :type nodes: const double*
    :param double* left:
       **[Output]** The minimal :math:`x`\-value :math:`m_x`.
    :param double* right:
@@ -39,32 +41,36 @@ Procedures
    .. code-block:: c
 
       void
-      BEZ_bbox(int *num_nodes,
-               double *nodes,
+      BEZ_bbox(const int *num_nodes,
+               const double *nodes,
                double *left,
                double *right,
                double *bottom,
                double *top);
 
-.. c:function:: void BEZ_contains_nd(int *num_nodes, \
-                                     int *dimension, \
-                                     double *nodes, \
-                                     double *point, \
+.. c:function:: void BEZ_contains_nd(const int *num_nodes, \
+                                     const int *dimension, \
+                                     const double *nodes, \
+                                     const double *point, \
                                      bool *predicate)
 
    Checks if a point :math:`p` is contained in the bounding box
    for a set of points.
 
-   :param int* num_nodes:
+   :param num_nodes:
       **[Input]** The number of nodes :math:`N` define the bounding box.
-   :param int* dimension:
+   :type num_nodes: const int*
+   :param dimension:
       **[Input]** The dimension :math:`D` such that the nodes and point lie in
       :math:`\mathbf{R}^D`.
-   :param double* nodes:
+   :type dimension: const int*
+   :param nodes:
       **[Input]** The actual nodes as a :math:`D \times N` array. This should
       be laid out in Fortran order, with :math:`D N` total values.
-   :param double* point:
+   :type nodes: const double*
+   :param point:
       **[Input]** The point :math:`p` as an array containing :math:`D` values.
+   :type point: const double*
    :param bool* predicate:
       **[Output]** Flag indicating if the point lies inside the box.
 
@@ -73,14 +79,14 @@ Procedures
    .. code-block:: c
 
       void
-      BEZ_contains_nd(int *num_nodes,
-                      int *dimension,
-                      double *nodes,
-                      double *point,
+      BEZ_contains_nd(const int *num_nodes,
+                      const int *dimension,
+                      const double *nodes,
+                      const double *point,
                       bool *predicate);
 
-.. c:function:: void BEZ_cross_product(double *vec0, \
-                                       double *vec1, \
+.. c:function:: void BEZ_cross_product(const double *vec0, \
+                                       const double *vec1, \
                                        double *result)
 
    Computes the cross-product of two vectors :math:`v_1, v_2` in
@@ -88,10 +94,12 @@ Procedures
    :math:`\mathbf{R}^3` and the result is the resulting :math:`z`\-component
    :math:`x_1 y_2 - x_2 y_1`.
 
-   :param double* vec0:
+   :param vec0:
       **[Input]** The first vector :math:`v_1` in :math:`\mathbf{R}^2`.
-   :param double* vec1:
+   :type vec0: const double*
+   :param vec1:
       **[Input]** The second vector :math:`v_2` in :math:`\mathbf{R}^2`.
+   :type vec1: const double*
    :param double* result:
       **[Output]** The cross-product.
 
@@ -100,23 +108,26 @@ Procedures
    .. code-block:: c
 
       void
-      BEZ_cross_product(double *vec0,
-                        double *vec1,
+      BEZ_cross_product(const double *vec0,
+                        const double *vec1,
                         double *result);
 
-.. c:function:: bool BEZ_in_interval(double *value, \
-                                     double *start, \
-                                     double *end)
+.. c:function:: bool BEZ_in_interval(const double *value, \
+                                     const double *start, \
+                                     const double *end)
 
    Checks if a value :math:`v` is in an interval :math:`\left[s, e\right]`.
 
-   :param double* value:
+   :param value:
       **[Input]** The value :math:`v`.
-   :param double* start:
+   :type value: const double*
+   :param start:
       **[Input]** The start :math:`s` of the interval
       :math:`\left[s, e\right]`.
-   :param double* end:
+   :type start: const double*
+   :param end:
       **[Input]** The end :math:`e` of the interval :math:`\left[s, e\right]`.
+   :type end: const double*
    :returns: Flag indicating if :math:`v \in \left[s, e\right]`.
    :rtype: bool
 
@@ -125,28 +136,32 @@ Procedures
    .. code-block:: c
 
       bool
-      BEZ_in_interval(double *value,
-                     double *start,
-                     double *end);
+      BEZ_in_interval(const double *value,
+                      const double *start,
+                      const double *end);
 
-.. c:function:: void BEZ_polygon_collide(int *polygon_size1, \
-                                         double *polygon1, \
-                                         int *polygon_size2, \
-                                         double *polygon2, \
+.. c:function:: void BEZ_polygon_collide(const int *polygon_size1, \
+                                         const double *polygon1, \
+                                         const int *polygon_size2, \
+                                         const double *polygon2, \
                                          bool *collision)
 
    Determines if two polygons collide.
 
-   :param int* polygon_size1:
+   :param polygon_size1:
       **[Input]** The number of sides :math:`N_1` in the first polygon.
-   :param double* polygon1:
+   :type polygon_size1: const int*
+   :param polygon1:
       **[Input]** The nodes of the first polygon as a :math:`2 \times N_1`
       array. This should be laid out in Fortran order.
-   :param int* polygon_size2:
+   :type polygon1: const double*
+   :param polygon_size2:
       **[Input]** The number of sides :math:`N_2` in the second polygon.
-   :param double* polygon2:
+   :type polygon_size2: const int*
+   :param polygon2:
       **[Input]** The nodes of the second polygon as a :math:`2 \times N_2`
       array. This should be laid out in Fortran order.
+   :type polygon2: const double*
    :param bool* collision:
       **[Output]** Flag indicating if the polygons collide.
 
@@ -155,24 +170,26 @@ Procedures
    .. code-block:: c
 
       void
-      BEZ_polygon_collide(int *polygon_size1,
-                          double *polygon1,
-                          int *polygon_size2,
-                          double *polygon2,
+      BEZ_polygon_collide(const int *polygon_size1,
+                          const double *polygon1,
+                          const int *polygon_size2,
+                          const double *polygon2,
                           bool *collision);
 
-.. c:function:: void BEZ_simple_convex_hull(int *num_points, \
-                                            double *points, \
+.. c:function:: void BEZ_simple_convex_hull(const int *num_points, \
+                                            const double *points, \
                                             int *polygon_size, \
                                             double *polygon)
 
    Computes the convex hull of a set of points.
 
-   :param int* num_points:
+   :param num_points:
       **[Input]** The number of points :math:`N`.
-   :param double* points:
+   :type num_points: const int*
+   :param points:
       **[Input]** The points being considered, as a :math:`2 \times N`
       array. This should be laid out in Fortran order.
+   :type points: const double*
    :param int* polygon_size:
       **[Output]** The number of sides :math:`M` in the convex hull. This
       will be at most :math:`N`.
@@ -186,32 +203,36 @@ Procedures
    .. code-block:: c
 
       void
-      BEZ_simple_convex_hull(int *num_points,
-                             double *points,
+      BEZ_simple_convex_hull(const int *num_points,
+                             const double *points,
                              int *polygon_size,
                              double *polygon);
 
-.. c:function:: bool BEZ_vector_close(int *num_values, \
-                                      double *vec1, \
-                                      double *vec2, \
-                                      double *eps)
+.. c:function:: bool BEZ_vector_close(const int *num_values, \
+                                      const double *vec1, \
+                                      const double *vec2, \
+                                      const double *eps)
 
    Determines if two vectors are close to machine precision.
 
-   :param int* num_values:
+   :param num_values:
       **[Input]** The dimension :math:`D` such that the vectors lie in
       :math:`\mathbf{R}^D`.
-   :param double* vec1:
+   :type num_values: const int*
+   :param vec1:
       **[Input]** The first vector :math:`v_1`, as an array of :math:`D`
       values.
-   :param double* vec2:
+   :type vec1: const double*
+   :param vec2:
       **[Input]** The second vector :math:`v_2`, as an array of :math:`D`
       values.
-   :param double* eps:
+   :type vec2: const double*
+   :param eps:
       **[Input]** The tolerance :math:`\varepsilon` used when comparing
       :math:`\left\lVert v_1 - v_2 \right\rVert` to
       :math:`\left\lVert v_1 \right\rVert` and
       :math:`\left\lVert v_2 \right\rVert`.
+   :type eps: const double*
    :returns:
       Flag indicating if :math:`v_1` and :math:`v_2` are close to the desired
       precision.
@@ -222,12 +243,12 @@ Procedures
    .. code-block:: c
 
       bool
-      BEZ_vector_close(int *num_values,
-                       double *vec1,
-                       double *vec2,
-                       double *eps);
+      BEZ_vector_close(const int *num_values,
+                       const double *vec1,
+                       const double *vec2,
+                       const double *eps);
 
-.. c:function:: void BEZ_wiggle_interval(double *value, \
+.. c:function:: void BEZ_wiggle_interval(const double *value, \
                                          double *result, \
                                          bool *success)
 
@@ -246,8 +267,9 @@ Procedures
    * :math:`v \in \left[1 + 2^{-44}, \infty\right)` will not be rounded
      and will set ``success`` to ``FALSE``.
 
-   :param double* value:
+   :param value:
       **[Input]** The value :math:`v` to be rounded.
+   :type value: const double*
    :param double* result:
       **[Output]** The rounded version of :math:`v`. If ``success`` is
       ``FALSE`` this is undefined.
@@ -260,6 +282,6 @@ Procedures
    .. code-block:: c
 
       void
-      BEZ_wiggle_interval(double *value,
+      BEZ_wiggle_interval(const double *value,
                           double *result,
                           bool *success);

--- a/docs/abi/surface.rst
+++ b/docs/abi/surface.rst
@@ -25,7 +25,7 @@ Procedures
 
 .. c:function:: void BEZ_compute_area(const int *num_edges, \
                                       const int *sizes, \
-                                      const double **nodes_pointers, \
+                                      const double* const* nodes_pointers, \
                                       double *area, \
                                       bool *not_implemented)
 
@@ -46,8 +46,10 @@ Procedures
    :param nodes_pointers:
       **[Input]** An array of :math:`N` pointers. Pointer :math:`j` points to
       the start of the edge :math:`E_j` along the boundary of the curved
-      polygon.
-   :type nodes_pointers: const double**
+      polygon. (This is a ``const`` array of ``const`` pointers, i.e. the
+      ``double**`` pointer array cannot be modified and the underlying
+      ``double*`` arrays pointed to by each element cannot be modified.)
+   :type nodes_pointers: const double* const*
    :param double* area:
       **[Output]** The computed area of the curved polygon. If
       ``not_implemented`` is ``TRUE``, then this is undefined.
@@ -63,7 +65,7 @@ Procedures
       void
       BEZ_compute_area(const int *num_edges,
                        const int *sizes,
-                       const double **nodes_pointers,
+                       const double* const* nodes_pointers,
                        double *area,
                        bool *not_implemented);
 

--- a/docs/abi/surface.rst
+++ b/docs/abi/surface.rst
@@ -23,9 +23,9 @@ B |eacute| zier `surface`_.
 Procedures
 **********
 
-.. c:function:: void BEZ_compute_area(int *num_edges, \
-                                      int *sizes, \
-                                      double **nodes_pointers, \
+.. c:function:: void BEZ_compute_area(const int *num_edges, \
+                                      const int *sizes, \
+                                      const double **nodes_pointers, \
                                       double *area, \
                                       bool *not_implemented)
 
@@ -36,15 +36,18 @@ Procedures
    * have no intersections with another edge (including self)
    * are oriented in the direction of the exterior
 
-   :param int* num_edges:
+   :param num_edges:
       **[Input]** The number of edges :math:`N` that bound the curved polygon.
-   :param int* sizes:
+   :type num_edges: const int*
+   :param sizes:
       **[Input]** An array of the size (i.e. the number of nodes) of each
       of the :math:`N` edges.
-   :param double** nodes_pointers:
+   :type sizes: const int*
+   :param nodes_pointers:
       **[Input]** An array of :math:`N` pointers. Pointer :math:`j` points to
       the start of the edge :math:`E_j` along the boundary of the curved
       polygon.
+   :type nodes_pointers: const double**
    :param double* area:
       **[Output]** The computed area of the curved polygon. If
       ``not_implemented`` is ``TRUE``, then this is undefined.
@@ -58,16 +61,16 @@ Procedures
    .. code-block:: c
 
       void
-      BEZ_compute_area(int *num_edges,
-                       int *sizes,
-                       double **nodes_pointers,
+      BEZ_compute_area(const int *num_edges,
+                       const int *sizes,
+                       const double **nodes_pointers,
                        double *area,
                        bool *not_implemented);
 
-.. c:function:: void BEZ_compute_edge_nodes(int *num_nodes, \
-                                            int *dimension, \
-                                            double *nodes, \
-                                            int *degree, \
+.. c:function:: void BEZ_compute_edge_nodes(const int *num_nodes, \
+                                            const int *dimension, \
+                                            const double *nodes, \
+                                            const int *degree, \
                                             double *nodes1, \
                                             double *nodes2, \
                                             double *nodes3)
@@ -97,18 +100,22 @@ Procedures
           f & d & a \end{array}\right].
       \end{align*}
 
-   :param int* num_nodes:
+   :param num_nodes:
       **[Input]** The number of nodes :math:`N` in the control net of the
       B |eacute| zier surface.
-   :param int* dimension:
+   :type num_nodes: const int*
+   :param dimension:
       **[Input]** The dimension :math:`D` such that the surface lies in
       :math:`\mathbf{R}^D`.
-   :param double* nodes:
+   :type dimension: const int*
+   :param nodes:
       **[Input]** The actual control net of the B |eacute| zier surface as a
       :math:`D \times N` array. This should be laid out in Fortran order, with
       :math:`D N` total values.
-   :param int* degree:
+   :type nodes: const double*
+   :param degree:
       **[Input]** The degree :math:`d` of the B |eacute| zier surface.
+   :type degree: const int*
    :param double* nodes1:
       **[Output]** The control points of the first edge B |eacute| zier curve
       as a :math:`D \times (d + 1)` array, laid out in Fortran order.
@@ -124,21 +131,21 @@ Procedures
    .. code-block:: c
 
       void
-      BEZ_compute_edge_nodes(int *num_nodes,
-                             int *dimension,
-                             double *nodes,
-                             int *degree,
+      BEZ_compute_edge_nodes(const int *num_nodes,
+                             const int *dimension,
+                             const double *nodes,
+                             const int *degree,
                              double *nodes1,
                              double *nodes2,
                              double *nodes3);
 
-.. c:function:: void BEZ_de_casteljau_one_round(int *num_nodes, \
-                                                int *dimension, \
-                                                double *nodes, \
-                                                int *degree, \
-                                                double *lambda1, \
-                                                double *lambda2, \
-                                                double *lambda3, \
+.. c:function:: void BEZ_de_casteljau_one_round(const int *num_nodes, \
+                                                const int *dimension, \
+                                                const double *nodes, \
+                                                const int *degree, \
+                                                const double *lambda1, \
+                                                const double *lambda2, \
+                                                const double *lambda3, \
                                                 double *new_nodes)
 
    This performs a single round of the de Casteljau algorithm for evaluation
@@ -150,25 +157,32 @@ Procedures
       v_{i, j, k}^{d - 1} = \lambda_1 v_{i + 1, j, k}^d +
           \lambda_2 v_{i, j + 1, k}^d + \lambda_3 v_{i, j, k + 1}^d.
 
-   :param int* num_nodes:
+   :param num_nodes:
       **[Input]** The number of nodes :math:`N` in the control net of the
       B |eacute| zier surface.
-   :param int* dimension:
+   :type num_nodes: const int*
+   :param dimension:
       **[Input]** The dimension :math:`D` such that the surface lies in
       :math:`\mathbf{R}^D`.
-   :param double* nodes:
+   :type dimension: const int*
+   :param nodes:
       **[Input]** The actual control net of the B |eacute| zier surface as a
       :math:`D \times N` array. This should be laid out in Fortran order, with
       :math:`D N` total values.
-   :param int* degree:
+   :type nodes: const double*
+   :param degree:
       **[Input]** The degree :math:`d` of the B |eacute| zier surface.
-   :param double* lambda1:
+   :type degree: const int*
+   :param lambda1:
       **[Input]** The first barycentric parameter along the reference triangle.
-   :param double* lambda2:
+   :type lambda1: const double*
+   :param lambda2:
       **[Input]** The second barycentric parameter along the reference
       triangle.
-   :param double* lambda3:
+   :type lambda2: const double*
+   :param lambda3:
       **[Input]** The third barycentric parameter along the reference triangle.
+   :type lambda3: const double*
    :param double* new_nodes:
       **[Output]** The newly-formed degree :math:`d - 1` control net. This will
       be a :math:`D \times (N - d - 1)` array.
@@ -178,46 +192,53 @@ Procedures
    .. code-block:: c
 
       void
-      BEZ_de_casteljau_one_round(int *num_nodes,
-                                 int *dimension,
-                                 double *nodes,
-                                 int *degree,
-                                 double *lambda1,
-                                 double *lambda2,
-                                 double *lambda3,
+      BEZ_de_casteljau_one_round(const int *num_nodes,
+                                 const int *dimension,
+                                 const double *nodes,
+                                 const int *degree,
+                                 const double *lambda1,
+                                 const double *lambda2,
+                                 const double *lambda3,
                                  double *new_nodes);
 
-.. c:function:: void BEZ_evaluate_barycentric(int *num_nodes, \
-                                              int *dimension, \
-                                              double *nodes, \
-                                              int *degree, \
-                                              double *lambda1, \
-                                              double *lambda2, \
-                                              double *lambda3, \
+.. c:function:: void BEZ_evaluate_barycentric(const int *num_nodes, \
+                                              const int *dimension, \
+                                              const double *nodes, \
+                                              const int *degree, \
+                                              const double *lambda1, \
+                                              const double *lambda2, \
+                                              const double *lambda3, \
                                               double *point)
 
    Evaluates a single point on a B |eacute| zier surface, with input
    in barycentric coordinates: :math:`B(\lambda_1, \lambda_2, \lambda_3)`.
 
-   :param int* num_nodes:
+   :param num_nodes:
       **[Input]** The number of nodes :math:`N` in the control net of the
       B |eacute| zier surface.
-   :param int* dimension:
+   :type num_nodes: const int*
+   :param dimension:
       **[Input]** The dimension :math:`D` such that the surface lies in
       :math:`\mathbf{R}^D`.
-   :param double* nodes:
+   :type dimension: const int*
+   :param nodes:
       **[Input]** The actual control net of the B |eacute| zier surface as a
       :math:`D \times N` array. This should be laid out in Fortran order, with
       :math:`D N` total values.
-   :param int* degree:
+   :type nodes: const double*
+   :param degree:
       **[Input]** The degree :math:`d` of the B |eacute| zier surface.
+   :type degree: const int*
    :param double* lambda1:
       **[Input]** The first barycentric parameter along the reference triangle.
-   :param double* lambda2:
+   :type lambda1: const double*
+   :param lambda2:
       **[Input]** The second barycentric parameter along the reference
       triangle.
-   :param double* lambda3:
+   :type lambda2: const double*
+   :param lambda3:
       **[Input]** The third barycentric parameter along the reference triangle.
+   :type lambda3: const double*
    :param double* point:
       **[Output]** A :math:`D \times 1` array, will contain
       :math:`B(\lambda_1, \lambda_2, \lambda_3)`.
@@ -227,47 +248,53 @@ Procedures
    .. code-block:: c
 
       void
-      BEZ_evaluate_barycentric(int *num_nodes,
-                               int *dimension,
-                               double *nodes,
-                               int *degree,
-                               double *lambda1,
-                               double *lambda2,
-                               double *lambda3,
+      BEZ_evaluate_barycentric(const int *num_nodes,
+                               const int *dimension,
+                               const double *nodes,
+                               const int *degree,
+                               const double *lambda1,
+                               const double *lambda2,
+                               const double *lambda3,
                                double *point);
 
-.. c:function:: void BEZ_evaluate_barycentric_multi(int *num_nodes, \
-                                                    int *dimension, \
-                                                    double *nodes, \
-                                                    int *degree, \
-                                                    int *num_vals, \
-                                                    double *param_vals, \
+.. c:function:: void BEZ_evaluate_barycentric_multi(const int *num_nodes, \
+                                                    const int *dimension, \
+                                                    const double *nodes, \
+                                                    const int *degree, \
+                                                    const int *num_vals, \
+                                                    const double *param_vals, \
                                                     double *evaluated)
 
    Evaluates many points on a B |eacute| zier surface, with input
    in barycentric coordinates:
    :math:`\left\{B(\lambda_{1,j}, \lambda_{2,j}, \lambda_{3,j})\right\}_j`.
 
-   :param int* num_nodes:
+   :param num_nodes:
       **[Input]** The number of nodes :math:`N` in the control net of the
       B |eacute| zier surface.
-   :param int* dimension:
+   :type num_nodes: const int*
+   :param dimension:
       **[Input]** The dimension :math:`D` such that the surface lies in
       :math:`\mathbf{R}^D`.
-   :param double* nodes:
+   :type dimension: const int*
+   :param nodes:
       **[Input]** The actual control net of the B |eacute| zier surface as a
       :math:`D \times N` array. This should be laid out in Fortran order, with
       :math:`D N` total values.
-   :param int* degree:
+   :type nodes: const double*
+   :param degree:
       **[Input]** The degree :math:`d` of the B |eacute| zier surface.
-   :param int* num_vals:
+   :type degree: const int*
+   :param num_vals:
       **[Input]** The number of points :math:`k` where :math:`B` is
       being evaluated.
-   :param double* param_vals:
+   :type num_vals: const int*
+   :param param_vals:
       **[Input]** A :math:`k \times 3` array of :math:`k` triples of
       barycentric coordinates, laid out in Fortran order. This way, the
       first column contains all :math:`\lambda_1` values in contiguous order,
       and similarly for the other columns.
+   :type param_vals: const double*
    :param double* evaluated:
       **[Output]** A :math:`D \times k` array of all evaluated points on the
       surface. Column :math:`j` will contain
@@ -278,20 +305,20 @@ Procedures
    .. code-block:: c
 
       void
-      BEZ_evaluate_barycentric_multi(int *num_nodes,
-                                     int *dimension,
-                                     double *nodes,
-                                     int *degree,
-                                     int *num_vals,
-                                     double *param_vals,
+      BEZ_evaluate_barycentric_multi(const int *num_nodes,
+                                     const int *dimension,
+                                     const double *nodes,
+                                     const int *degree,
+                                     const int *num_vals,
+                                     const double *param_vals,
                                      double *evaluated);
 
-.. c:function:: void BEZ_evaluate_cartesian_multi(int *num_nodes, \
-                                                  int *dimension, \
-                                                  double *nodes, \
-                                                  int *degree, \
-                                                  int *num_vals, \
-                                                  double *param_vals, \
+.. c:function:: void BEZ_evaluate_cartesian_multi(const int *num_nodes, \
+                                                  const int *dimension, \
+                                                  const double *nodes, \
+                                                  const int *degree, \
+                                                  const int *num_vals, \
+                                                  const double *param_vals, \
                                                   double *evaluated)
 
    Evaluates many points on a B |eacute| zier surface, with input
@@ -300,26 +327,32 @@ Procedures
    equivalent to the barycentric input :math:`\lambda_1 = 1 - s - t`,
    :math:`\lambda_2 = s` and :math:`\lambda_3 = t`.
 
-   :param int* num_nodes:
+   :param num_nodes:
       **[Input]** The number of nodes :math:`N` in the control net of the
       B |eacute| zier surface.
-   :param int* dimension:
+   :type num_nodes: const int*
+   :param dimension:
       **[Input]** The dimension :math:`D` such that the surface lies in
       :math:`\mathbf{R}^D`.
-   :param double* nodes:
+   :type dimension: const int*
+   :param nodes:
       **[Input]** The actual control net of the B |eacute| zier surface as a
       :math:`D \times N` array. This should be laid out in Fortran order, with
       :math:`D N` total values.
-   :param int* degree:
+   :type nodes: const double*
+   :param degree:
       **[Input]** The degree :math:`d` of the B |eacute| zier surface.
-   :param int* num_vals:
+   :type degree: const int*
+   :param num_vals:
       **[Input]** The number of points :math:`k` where :math:`B` is
       being evaluated.
-   :param double* param_vals:
+   :type num_vals: const int*
+   :param param_vals:
       **[Input]** A :math:`k \times 2` array of :math:`k` pairs of
       cartesian coordinates, laid out in Fortran order. This way, the
       first column contains all :math:`s`\-values in contiguous order,
       and similarly for the other column.
+   :type param_vals: const double*
    :param double* evaluated:
       **[Output]** A :math:`D \times k` array of all evaluated points on the
       surface. Column :math:`j` will contain
@@ -330,36 +363,40 @@ Procedures
    .. code-block:: c
 
       void
-      BEZ_evaluate_cartesian_multi(int *num_nodes,
-                                   int *dimension,
-                                   double *nodes,
-                                   int *degree,
-                                   int *num_vals,
-                                   double *param_vals,
+      BEZ_evaluate_cartesian_multi(const int *num_nodes,
+                                   const int *dimension,
+                                   const double *nodes,
+                                   const int *degree,
+                                   const int *num_vals,
+                                   const double *param_vals,
                                    double *evaluated);
 
-.. c:function:: void BEZ_jacobian_both(int *num_nodes, \
-                                       int *dimension, \
-                                       double *nodes, \
-                                       int *degree, \
+.. c:function:: void BEZ_jacobian_both(const int *num_nodes, \
+                                       const int *dimension, \
+                                       const double *nodes, \
+                                       const int *degree, \
                                        double *new_nodes)
 
    Computes control nets for both cartesian partial derivatives of a
    B |eacute| zier surface :math:`B_s(s, t)` and :math:`B_t(s, t)`. Taking
    a single (partial) derivative lowers the degree by 1.
 
-   :param int* num_nodes:
+   :param num_nodes:
       **[Input]** The number of nodes :math:`N` in the control net of the
       B |eacute| zier surface.
-   :param int* dimension:
+   :type num_nodes: const int*
+   :param dimension:
       **[Input]** The dimension :math:`D` such that the surface lies in
       :math:`\mathbf{R}^D`.
-   :param double* nodes:
+   :type dimension: const int*
+   :param nodes:
       **[Input]** The actual control net of the B |eacute| zier surface as a
       :math:`D \times N` array. This should be laid out in Fortran order, with
       :math:`D N` total values.
-   :param int* degree:
+   :type nodes: const double*
+   :param degree:
       **[Input]** The degree :math:`d` of the B |eacute| zier surface.
+   :type degree: const int*
    :param double* new_nodes:
       **[Output]** The combined control nets :math:`B_s` and :math:`B_t` as
       a :math:`(2D) \times (N - d - 1)` array, laid out in Fortran order. The
@@ -371,40 +408,45 @@ Procedures
    .. code-block:: c
 
       void
-      BEZ_jacobian_both(int *num_nodes,
-                        int *dimension,
-                        double *nodes,
-                        int *degree,
+      BEZ_jacobian_both(const int *num_nodes,
+                        const int *dimension,
+                        const double *nodes,
+                        const int *degree,
                         double *new_nodes);
 
-.. c:function:: void BEZ_jacobian_det(int *num_nodes, \
-                                      double *nodes, \
-                                      int *degree, \
-                                      int *num_vals, \
-                                      double *param_vals, \
+.. c:function:: void BEZ_jacobian_det(const int *num_nodes, \
+                                      const double *nodes, \
+                                      const int *degree, \
+                                      const int *num_vals, \
+                                      const double *param_vals, \
                                       double *evaluated)
 
    Computes :math:`\det(DB)` at many points :math:`(s_j, t_j)`. This is only
    well-defined if :math:`\det(DB)` has two rows, hence the surface must lie
    in :math:`\mathbf{R}^2`.
 
-   :param int* num_nodes:
+   :param num_nodes:
       **[Input]** The number of nodes :math:`N` in the control net of the
       B |eacute| zier surface.
-   :param double* nodes:
+   :type num_nodes: const int*
+   :param nodes:
       **[Input]** The actual control net of the B |eacute| zier surface as a
       :math:`2 \times N` array. This should be laid out in Fortran order, with
       :math:`2 N` total values.
-   :param int* degree:
+   :type nodes: const double*
+   :param degree:
       **[Input]** The degree :math:`d` of the B |eacute| zier surface.
-   :param int* num_vals:
+   :type degree: const int*
+   :param num_vals:
       **[Input]** The number of points :math:`k` where :math:`\det(DB)` is
       being evaluated.
-   :param double* param_vals:
+   :type num_vals: const int*
+   :param param_vals:
       **[Input]** A :math:`k \times 2` array of :math:`k` pairs of
       cartesian coordinates, laid out in Fortran order. This way, the
       first column contains all :math:`s`\-values in contiguous order,
       and similarly for the other column.
+   :type param_vals: const double*
    :param double* evaluated:
       **[Output]** A :math:`k` array of all evaluated determinants. The
       :math:`j`\-th value will be :math:`\det(DB(s_j, t_j))`.
@@ -414,49 +456,56 @@ Procedures
    .. code-block:: c
 
       void
-      BEZ_jacobian_det(int *num_nodes,
-                       double *nodes,
-                       int *degree,
-                       int *num_vals,
-                       double *param_vals,
+      BEZ_jacobian_det(const int *num_nodes,
+                       const double *nodes,
+                       const int *degree,
+                       const int *num_vals,
+                       const double *param_vals,
                        double *evaluated);
 
-.. c:function:: void BEZ_specialize_surface(int *num_nodes, \
-                                            int *dimension, \
-                                            double *nodes, \
-                                            int *degree, \
-                                            double *weights_a, \
-                                            double *weights_b, \
-                                            double *weights_c, \
+.. c:function:: void BEZ_specialize_surface(const int *num_nodes, \
+                                            const int *dimension, \
+                                            const double *nodes, \
+                                            const int *degree, \
+                                            const double *weights_a, \
+                                            const double *weights_b, \
+                                            const double *weights_c, \
                                             double *specialized)
 
    Changes the control net for a B |eacute| zier surface by specializing
    from the original triangle :math:`(0, 0), (1, 0), (0, 1)` to a new
    triangle :math:`p_1, p_2, p_3`.
 
-   :param int* num_nodes:
+   :param num_nodes:
       **[Input]** The number of nodes :math:`N` in the control net of the
       B |eacute| zier surface.
-   :param int* dimension:
+   :type num_nodes: const int*
+   :param dimension:
       **[Input]** The dimension :math:`D` such that the surface lies in
       :math:`\mathbf{R}^D`.
-   :param double* nodes:
+   :type dimension: const int*
+   :param nodes:
       **[Input]** The actual control net of the B |eacute| zier surface as a
       :math:`D \times N` array. This should be laid out in Fortran order, with
       :math:`D N` total values.
-   :param int* degree:
+   :type nodes: const double*
+   :param degree:
       **[Input]** The degree :math:`d` of the B |eacute| zier surface.
-   :param double* weights_a:
+   :type degree: const int*
+   :param weights_a:
       **[Input]** A 3-array containing the barycentric weights for the first
       node :math:`p_1` in the new triangle.
-   :param double* weights_b:
+   :type weights_a: const double*
+   :param weights_b:
       **[Input]** A 3-array containing the barycentric weights for the second
       node :math:`p_2` in the new triangle.
-   :param double* weights_c:
+   :type weights_b: const double*
+   :param weights_c:
       **[Input]** A 3-array containing the barycentric weights for the third
       node :math:`p_3` in the new triangle.
+   :type weights_c: const double*
    :param double* specialized:
-      **[Input]** The control net of the newly formed B |eacute| zier surface
+      **[Output]** The control net of the newly formed B |eacute| zier surface
       as a :math:`D \times N` array.
 
    **Signature:**
@@ -464,19 +513,19 @@ Procedures
    .. code-block:: c
 
       void
-      BEZ_specialize_surface(int *num_nodes,
-                             int *dimension,
-                             double *nodes,
-                             int *degree,
-                             double *weights_a,
-                             double *weights_b,
-                             double *weights_c,
+      BEZ_specialize_surface(const int *num_nodes,
+                             const int *dimension,
+                             const double *nodes,
+                             const int *degree,
+                             const double *weights_a,
+                             const double *weights_b,
+                             const double *weights_c,
                              double *specialized);
 
-.. c:function:: void BEZ_subdivide_nodes_surface(int *num_nodes, \
-                                                 int *dimension, \
-                                                 double *nodes, \
-                                                 int *degree, \
+.. c:function:: void BEZ_subdivide_nodes_surface(const int *num_nodes, \
+                                                 const int *dimension, \
+                                                 const double *nodes, \
+                                                 const int *degree, \
                                                  double *nodes_a, \
                                                  double *nodes_b, \
                                                  double *nodes_c, \
@@ -486,18 +535,22 @@ Procedures
    the original surface. See :meth:`.Surface.subdivide` for more
    details
 
-   :param int* num_nodes:
+   :param num_nodes:
       **[Input]** The number of nodes :math:`N` in the control net of the
       B |eacute| zier surface.
-   :param int* dimension:
+   :type num_nodes: const int*
+   :param dimension:
       **[Input]** The dimension :math:`D` such that the surface lies in
       :math:`\mathbf{R}^D`.
-   :param double* nodes:
+   :type dimension: const int*
+   :param nodes:
       **[Input]** The actual control net of the B |eacute| zier surface as a
       :math:`D \times N` array. This should be laid out in Fortran order, with
       :math:`D N` total values.
-   :param int* degree:
+   :type nodes: const double*
+   :param degree:
       **[Input]** The degree :math:`d` of the B |eacute| zier surface.
+   :type degree: const int*
    :param double* nodes_a:
       **[Output]** The control net of the lower left sub-surface as a
       :math:`D \times N` array, laid out in Fortran order.
@@ -516,10 +569,10 @@ Procedures
    .. code-block:: c
 
       void
-      BEZ_subdivide_nodes_surface(int *num_nodes,
-                                  int *dimension,
-                                  double *nodes,
-                                  int *degree,
+      BEZ_subdivide_nodes_surface(const int *num_nodes,
+                                  const int *dimension,
+                                  const double *nodes,
+                                  const int *degree,
                                   double *nodes_a,
                                   double *nodes_b,
                                   double *nodes_c,

--- a/docs/abi/surface_intersection.rst
+++ b/docs/abi/surface_intersection.rst
@@ -23,11 +23,11 @@ the B |eacute| zier curve segments that form the exterior.
 Procedures
 **********
 
-.. c:function:: void BEZ_locate_point_surface(int *num_nodes, \
-                                              double *nodes, \
-                                              int *degree, \
-                                              double *x_val, \
-                                              double *y_val, \
+.. c:function:: void BEZ_locate_point_surface(const int *num_nodes, \
+                                              const double *nodes, \
+                                              const int *degree, \
+                                              const double *x_val, \
+                                              const double *y_val, \
                                               double *s_val, \
                                               double *t_val)
 
@@ -40,19 +40,24 @@ Procedures
    throughout the unit triangle. (If this were not true, then multiple
    inputs could map to the same output.)
 
-   :param int* num_nodes:
+   :param num_nodes:
       **[Input]** The number of nodes :math:`N` in the control net of the
       B |eacute| zier surface.
-   :param double* nodes:
+   :type num_nodes: const int*
+   :param nodes:
       **[Input]** The actual control net of the B |eacute| zier surface as a
       :math:`2 \times N` array. This should be laid out in Fortran order, with
       :math:`2 N` total values.
-   :param int* degree:
+   :type nodes: const double*
+   :param degree:
       **[Input]** The degree :math:`d` of the B |eacute| zier surface.
-   :param double* x_val:
+   :type degree: const int*
+   :param x_val:
       **[Input]** The :math:`x`\-value of the point being located.
-   :param double* y_val:
+   :type x_val: const double*
+   :param y_val:
       **[Input]** The :math:`y`\-value of the point being located.
+   :type y_val: const double*
    :param double* s_val:
       **[Output]** The first parameter :math:`s` of the solution. If
       :math:`(x, y)` can't be located on the surface, then ``s_val = -1.0``.
@@ -66,21 +71,21 @@ Procedures
    .. code-block:: c
 
       void
-      BEZ_locate_point_surface(int *num_nodes,
-                               double *nodes,
-                               int *degree,
-                               double *x_val,
-                               double *y_val,
+      BEZ_locate_point_surface(const int *num_nodes,
+                               const double *nodes,
+                               const int *degree,
+                               const double *x_val,
+                               const double *y_val,
                                double *s_val,
                                double *t_val);
 
-.. c:function:: void BEZ_newton_refine_surface(int *num_nodes, \
-                                               double *nodes, \
-                                               int *degree, \
-                                               double *x_val, \
-                                               double *y_val, \
-                                               double *s, \
-                                               double *t, \
+.. c:function:: void BEZ_newton_refine_surface(const int *num_nodes, \
+                                               const double *nodes, \
+                                               const int *degree, \
+                                               const double *x_val, \
+                                               const double *y_val, \
+                                               const double *s, \
+                                               const double *t, \
                                                double *updated_s, \
                                                double *updated_t)
 
@@ -94,25 +99,32 @@ Procedures
       \left[\begin{array}{c} s_n \\ t_n \end{array}\right] -
       DB(s_n, t_n)^{-1} \left(B(s_n, t_n) - p\right).
 
-   :param int* num_nodes:
+   :param num_nodes:
       **[Input]** The number of nodes :math:`N` in the control net of the
       B |eacute| zier surface.
-   :param double* nodes:
+   :type num_nodes: const int*
+   :param nodes:
       **[Input]** The actual control net of the B |eacute| zier surface as a
       :math:`2 \times N` array. This should be laid out in Fortran order, with
       :math:`2 N` total values.
-   :param int* degree:
+   :type nodes: const double*
+   :param degree:
       **[Input]** The degree :math:`d` of the B |eacute| zier surface.
-   :param double* x_val:
+   :type degree: const int*
+   :param x_val:
       **[Input]** The :math:`x`\-value of the point :math:`p`.
-   :param double* y_val:
+   :type x_val: const double*
+   :param y_val:
       **[Input]** The :math:`y`\-value of the point :math:`p`.
-   :param double* s:
+   :type y_val: const double*
+   :param s:
       **[Input]** The first parameter :math:`s_n` of the current approximation
       of a solution.
-   :param double* t:
+   :type s: const double*
+   :param t:
       **[Input]** The second parameter :math:`t_n` of the current approximation
       of a solution.
+   :type t: const double*
    :param double* updated_s:
       **[Output]** The first parameter :math:`s_{n + 1}` of the updated
       approximation.
@@ -125,25 +137,25 @@ Procedures
    .. code-block:: c
 
       void
-      BEZ_newton_refine_surface(int *num_nodes,
-                                double *nodes,
-                                int *degree,
-                                double *x_val,
-                                double *y_val,
-                                double *s,
-                                double *t,
+      BEZ_newton_refine_surface(const int *num_nodes,
+                                const double *nodes,
+                                const int *degree,
+                                const double *x_val,
+                                const double *y_val,
+                                const double *s,
+                                const double *t,
                                 double *updated_s,
                                 double *updated_t);
 
-.. c:function:: void BEZ_surface_intersections(int *num_nodes1, \
-                                               double *nodes1, \
-                                               int *degree1, \
-                                               int *num_nodes2, \
-                                               double *nodes2, \
-                                               int *degree2, \
-                                               int *segment_ends_size, \
+.. c:function:: void BEZ_surface_intersections(const int *num_nodes1, \
+                                               const double *nodes1, \
+                                               const int *degree1, \
+                                               const int *num_nodes2, \
+                                               const double *nodes2, \
+                                               const int *degree2, \
+                                               const int *segment_ends_size, \
                                                int *segment_ends, \
-                                               int *segments_size, \
+                                               const int *segments_size, \
                                                CurvedPolygonSegment *segments, \
                                                int *num_intersected, \
                                                SurfaceContained *contained, \
@@ -174,27 +186,34 @@ Procedures
       static workspace around that will continue to grow as resizing is
       needed, but will never shrink.
 
-   :param int* num_nodes1:
+   :param num_nodes1:
       **[Input]** The number of nodes :math:`N_1` in the control net of the
       first B |eacute| zier surface.
-   :param double* nodes1:
+   :type num_nodes1: const int*
+   :param nodes1:
       **[Input]** The actual control net of the first B |eacute| zier surface
       as a :math:`2 \times N_1` array. This should be laid out in Fortran
       order, with :math:`2 N_1` total values.
-   :param int* degree1:
+   :type nodes1: const double*
+   :param degree1:
       **[Input]** The degree :math:`d_1` of the first B |eacute| zier surface.
-   :param int* num_nodes2:
+   :type degree1: const int*
+   :param num_nodes2:
       **[Input]** The number of nodes :math:`N_2` in the control net of the
       second B |eacute| zier surface.
-   :param double* nodes2:
+   :type num_nodes2: const int*
+   :param nodes2:
       **[Input]** The actual control net of the second B |eacute| zier surface
       as a :math:`2 \times N_2` array. This should be laid out in Fortran
       order, with :math:`2 N_2` total values.
-   :param int* degree2:
+   :type nodes2: const double*
+   :param degree2:
       **[Input]** The degree :math:`d_2` of the second B |eacute| zier surface.
-   :param int* segment_ends_size:
+   :type degree1: const int*
+   :param segment_ends_size:
       **[Input]** The size of ``segment_ends``, which must be pre-allocated by
       the caller.
+   :type segment_ends_size: const int*
    :param int* segment_ends:
       **[Output]** An array (pre-allocated by the caller) of the end indices
       for each group of segments in ``segments``. For example, if the surfaces
@@ -202,9 +221,10 @@ Procedures
       sides and the second of which has three, then the first two values in
       ``segment_ends`` will be ``[4, 7]`` and ``num_intersected`` will be
       ``2``.
-   :param int* segments_size:
+   :param segments_size:
       **[Input]** The size of ``segments``, which must be pre-allocated by
       the caller.
+   :type segments_size: const int*
    :param CurvedPolygonSegment* segments:
       **[Output]** An array (pre-allocated by the caller) of the edge segments
       that make up the boundary of the curved polygon(s) that form the
@@ -257,15 +277,15 @@ Procedures
    .. code-block:: c
 
       void
-      BEZ_surface_intersections(int *num_nodes1,
-                                double *nodes1,
-                                int *degree1,
-                                int *num_nodes2,
-                                double *nodes2,
-                                int *degree2,
-                                int *segment_ends_size,
+      BEZ_surface_intersections(const int *num_nodes1,
+                                const double *nodes1,
+                                const int *degree1,
+                                const int *num_nodes2,
+                                const double *nodes2,
+                                const int *degree2,
+                                const int *segment_ends_size,
                                 int *segment_ends,
-                                int *segments_size,
+                                const int *segments_size,
                                 CurvedPolygonSegment *segments,
                                 int *num_intersected,
                                 SurfaceContained *contained,

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -46,7 +46,7 @@ nitpicky = True
 # ``bool`` is not a stopword but ``_Bool`` is, because only ``_Bool``
 # is in the language (``bool`` requires ``<stdbool.h>``)
 sphinx.domains.c.CObject.stopwords.update(
-    ("bool", "const double", "const int")
+    ("bool", "const double", "const double* const", "const int")
 )
 nitpick_ignore = [("py:class", "bezier._base.Base")]
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -45,7 +45,9 @@ needs_sphinx = "1.7.0"
 nitpicky = True
 # ``bool`` is not a stopword but ``_Bool`` is, because only ``_Bool``
 # is in the language (``bool`` requires ``<stdbool.h>``)
-sphinx.domains.c.CObject.stopwords.add("bool")
+sphinx.domains.c.CObject.stopwords.update(
+    ("bool", "const double", "const int")
+)
 nitpick_ignore = [("py:class", "bezier._base.Base")]
 
 # Add any Sphinx extension module names here, as strings. They can be

--- a/docs/releases/latest.rst
+++ b/docs/releases/latest.rst
@@ -74,6 +74,13 @@ Breaking Changes
    (`#167 <https://github.com/dhermes/bezier/pull/167>`__).
    Fixed `#166 <https://github.com/dhermes/bezier/issues/166>`__.
 
+Additive Changes
+~~~~~~~~~~~~~~~~
+
+-  Changed all ``[in]`` arguments in C headers to ``const`` pointers
+   (`#169 <https://github.com/dhermes/bezier/pull/169>`__).
+   Fixed `#168 <https://github.com/dhermes/bezier/issues/168>`__.
+
 Bug Fixes
 ---------
 

--- a/src/fortran/include/bezier/curve.h
+++ b/src/fortran/include/bezier/curve.h
@@ -19,31 +19,35 @@
 extern "C" {
 #endif
 
-void BEZ_evaluate_curve_barycentric(int* num_nodes, int* dimension,
-    double* nodes, int* num_vals, double* lambda1, double* lambda2,
+void BEZ_evaluate_curve_barycentric(const int* num_nodes, const int* dimension,
+    const double* nodes, const int* num_vals, const double* lambda1,
+    const double* lambda2, double* evaluated);
+void BEZ_evaluate_multi(const int* num_nodes, const int* dimension,
+    const double* nodes, const int* num_vals, const double* s_vals,
     double* evaluated);
-void BEZ_evaluate_multi(int* num_nodes, int* dimension, double* nodes,
-    int* num_vals, double* s_vals, double* evaluated);
-void BEZ_specialize_curve(int* num_nodes, int* dimension, double* nodes,
-    double* start, double* end, double* new_nodes);
-void BEZ_evaluate_hodograph(double* s, int* num_nodes, int* dimension,
-    double* nodes, double* hodograph);
-void BEZ_subdivide_nodes_curve(int* num_nodes, int* dimension, double* nodes,
-    double* left_nodes, double* right_nodes);
-void BEZ_newton_refine_curve(int* num_nodes, int* dimension, double* nodes,
-    double* point, double* s, double* updated_s);
-void BEZ_locate_point_curve(int* num_nodes, int* dimension, double* nodes,
-    double* point, double* s_approx);
-void BEZ_elevate_nodes_curve(
-    int* num_nodes, int* dimension, double* nodes, double* elevated);
-void BEZ_get_curvature(int* num_nodes, double* nodes, double* tangent_vec,
-    double* s, double* curvature);
-void BEZ_reduce_pseudo_inverse(int* num_nodes, int* dimension, double* nodes,
-    double* reduced, bool* not_implemented);
-void BEZ_full_reduce(int* num_nodes, int* dimension, double* nodes,
-    int* num_reduced_nodes, double* reduced, bool* not_implemented);
-void BEZ_compute_length(int* num_nodes, int* dimension, double* nodes,
-    double* length, int* error_val);
+void BEZ_specialize_curve(const int* num_nodes, const int* dimension,
+    const double* nodes, const double* start, const double* end,
+    double* new_nodes);
+void BEZ_evaluate_hodograph(double* s, const int* num_nodes,
+    const int* dimension, const double* nodes, double* hodograph);
+void BEZ_subdivide_nodes_curve(const int* num_nodes, const int* dimension,
+    const double* nodes, double* left_nodes, double* right_nodes);
+void BEZ_newton_refine_curve(const int* num_nodes, const int* dimension,
+    const double* nodes, const double* point, const double* s,
+    double* updated_s);
+void BEZ_locate_point_curve(const int* num_nodes, const int* dimension,
+    const double* nodes, const double* point, double* s_approx);
+void BEZ_elevate_nodes_curve(const int* num_nodes, const int* dimension,
+    const double* nodes, double* elevated);
+void BEZ_get_curvature(const int* num_nodes, const double* nodes,
+    const double* tangent_vec, const double* s, double* curvature);
+void BEZ_reduce_pseudo_inverse(const int* num_nodes, const int* dimension,
+    const double* nodes, double* reduced, bool* not_implemented);
+void BEZ_full_reduce(const int* num_nodes, const int* dimension,
+    const double* nodes, int* num_reduced_nodes, double* reduced,
+    bool* not_implemented);
+void BEZ_compute_length(const int* num_nodes, const int* dimension,
+    const double* nodes, double* length, int* error_val);
 
 #if defined(__cplusplus)
 }

--- a/src/fortran/include/bezier/curve_intersection.h
+++ b/src/fortran/include/bezier/curve_intersection.h
@@ -26,14 +26,15 @@ typedef enum BoxIntersectionType {
     DISJOINT = 2,
 } BoxIntersectionType;
 
-void BEZ_newton_refine_curve_intersect(double* s, int* num_nodes1,
-    double* nodes1, double* t, int* num_nodes2, double* nodes2, double* new_s,
-    double* new_t, Status* status);
-void BEZ_bbox_intersect(int* num_nodes1, double* nodes1, int* num_nodes2,
-    double* nodes2, BoxIntersectionType* enum_);
-void BEZ_curve_intersections(int* num_nodes_first, double* nodes_first,
-    int* num_nodes_second, double* nodes_second, int* intersections_size,
-    double* intersections, int* num_intersections, bool* coincident,
+void BEZ_newton_refine_curve_intersect(const double* s, const int* num_nodes1,
+    const double* nodes1, const double* t, const int* num_nodes2,
+    const double* nodes2, double* new_s, double* new_t, Status* status);
+void BEZ_bbox_intersect(const int* num_nodes1, const double* nodes1,
+    const int* num_nodes2, const double* nodes2, BoxIntersectionType* enum_);
+void BEZ_curve_intersections(const int* num_nodes_first,
+    const double* nodes_first, const int* num_nodes_second,
+    const double* nodes_second, const int* intersections_size,
+    double* intersections, const int* num_intersections, bool* coincident,
     Status* status);
 void BEZ_free_curve_intersections_workspace(void);
 

--- a/src/fortran/include/bezier/helpers.h
+++ b/src/fortran/include/bezier/helpers.h
@@ -19,19 +19,20 @@
 extern "C" {
 #endif
 
-void BEZ_cross_product(double* vec0, double* vec1, double* result);
-void BEZ_bbox(int* num_nodes, double* nodes, double* left, double* right,
-    double* bottom, double* top);
-void BEZ_wiggle_interval(double* value, double* result, bool* success);
-void BEZ_contains_nd(int* num_nodes, int* dimension, double* nodes,
-    double* point, bool* predicate);
-bool BEZ_vector_close(
-    int* num_values, double* vec1, double* vec2, double* eps);
-bool BEZ_in_interval(double* value, double* start, double* end);
+void BEZ_cross_product(const double* vec0, const double* vec1, double* result);
+void BEZ_bbox(const int* num_nodes, const double* nodes, double* left,
+    double* right, double* bottom, double* top);
+void BEZ_wiggle_interval(const double* value, double* result, bool* success);
+void BEZ_contains_nd(const int* num_nodes, const int* dimension,
+    const double* nodes, const double* point, bool* predicate);
+bool BEZ_vector_close(int* num_values, const double* vec1, const double* vec2,
+    const double* eps);
+bool BEZ_in_interval(
+    const double* value, const double* start, const double* end);
 void BEZ_simple_convex_hull(
-    int* num_points, double* points, int* polygon_size, double* polygon);
-void BEZ_polygon_collide(int* polygon_size1, double* polygon1,
-    int* polygon_size2, double* polygon2, bool* collision);
+    int* num_points, const double* points, int* polygon_size, double* polygon);
+void BEZ_polygon_collide(const int* polygon_size1, const double* polygon1,
+    const int* polygon_size2, const double* polygon2, bool* collision);
 
 #if defined(__cplusplus)
 }

--- a/src/fortran/include/bezier/surface.h
+++ b/src/fortran/include/bezier/surface.h
@@ -19,32 +19,34 @@
 extern "C" {
 #endif
 
-void BEZ_de_casteljau_one_round(int* num_nodes, int* dimension, double* nodes,
-    int* degree, double* lambda1, double* lambda2, double* lambda3,
-    double* new_nodes);
-void BEZ_evaluate_barycentric(int* num_nodes, int* dimension, double* nodes,
-    int* degree, double* lambda1, double* lambda2, double* lambda3,
-    double* point);
-void BEZ_evaluate_barycentric_multi(int* num_nodes, int* dimension,
-    double* nodes, int* degree, int* num_vals, double* param_vals,
+void BEZ_de_casteljau_one_round(const int* num_nodes, const int* dimension,
+    const double* nodes, const int* degree, const double* lambda1,
+    const double* lambda2, const double* lambda3, double* new_nodes);
+void BEZ_evaluate_barycentric(const int* num_nodes, const int* dimension,
+    const double* nodes, const int* degree, const double* lambda1,
+    const double* lambda2, const double* lambda3, double* point);
+void BEZ_evaluate_barycentric_multi(const int* num_nodes, const int* dimension,
+    const double* nodes, const int* degree, const int* num_vals,
+    const double* param_vals, double* evaluated);
+void BEZ_evaluate_cartesian_multi(const int* num_nodes, const int* dimension,
+    const double* nodes, const int* degree, const int* num_vals,
+    const double* param_vals, double* evaluated);
+void BEZ_jacobian_both(const int* num_nodes, const int* dimension,
+    const double* nodes, const int* degree, double* new_nodes);
+void BEZ_jacobian_det(const int* num_nodes, const double* nodes,
+    const int* degree, const int* num_vals, const double* param_vals,
     double* evaluated);
-void BEZ_evaluate_cartesian_multi(int* num_nodes, int* dimension,
-    double* nodes, int* degree, int* num_vals, double* param_vals,
-    double* evaluated);
-void BEZ_jacobian_both(int* num_nodes, int* dimension, double* nodes,
-    int* degree, double* new_nodes);
-void BEZ_jacobian_det(int* num_nodes, double* nodes, int* degree,
-    int* num_vals, double* param_vals, double* evaluated);
-void BEZ_specialize_surface(int* num_nodes, int* dimension, double* nodes,
-    int* degree, double* weights_a, double* weights_b, double* weights_c,
-    double* specialized);
-void BEZ_subdivide_nodes_surface(int* num_nodes, int* dimension, double* nodes,
-    int* degree, double* nodes_a, double* nodes_b, double* nodes_c,
-    double* nodes_d);
-void BEZ_compute_edge_nodes(int* num_nodes, int* dimension, double* nodes,
-    int* degree, double* nodes1, double* nodes2, double* nodes3);
-void BEZ_compute_area(int* num_edges, int* sizes, double** nodes_pointers,
-    double* area, bool* not_implemented);
+void BEZ_specialize_surface(const int* num_nodes, const int* dimension,
+    const double* nodes, const int* degree, const double* weights_a,
+    const double* weights_b, const double* weights_c, double* specialized);
+void BEZ_subdivide_nodes_surface(const int* num_nodes, const int* dimension,
+    const double* nodes, const int* degree, double* nodes_a, double* nodes_b,
+    double* nodes_c, double* nodes_d);
+void BEZ_compute_edge_nodes(const int* num_nodes, const int* dimension,
+    const double* nodes, const int* degree, double* nodes1, double* nodes2,
+    double* nodes3);
+void BEZ_compute_area(int* num_edges, int* sizes,
+    const double** nodes_pointers, double* area, bool* not_implemented);
 
 #if defined(__cplusplus)
 }

--- a/src/fortran/include/bezier/surface.h
+++ b/src/fortran/include/bezier/surface.h
@@ -46,7 +46,7 @@ void BEZ_compute_edge_nodes(const int* num_nodes, const int* dimension,
     const double* nodes, const int* degree, double* nodes1, double* nodes2,
     double* nodes3);
 void BEZ_compute_area(int* num_edges, int* sizes,
-    const double** nodes_pointers, double* area, bool* not_implemented);
+    const double* const* nodes_pointers, double* area, bool* not_implemented);
 
 #if defined(__cplusplus)
 }

--- a/src/fortran/include/bezier/surface_intersection.h
+++ b/src/fortran/include/bezier/surface_intersection.h
@@ -31,15 +31,17 @@ typedef struct CurvedPolygonSegment {
     int edge_index;
 } CurvedPolygonSegment;
 
-void BEZ_newton_refine_surface(int* num_nodes, double* nodes, int* degree,
-    double* x_val, double* y_val, double* s, double* t, double* updated_s,
-    double* updated_t);
-void BEZ_locate_point_surface(int* num_nodes, double* nodes, int* degree,
-    double* x_val, double* y_val, double* s_val, double* t_val);
-void BEZ_surface_intersections(int* num_nodes1, double* nodes1, int* degree1,
-    int* num_nodes2, double* nodes2, int* degree2, int* segment_ends_size,
-    int* segment_ends, int* segments_size, CurvedPolygonSegment* segments,
-    int* num_intersected, SurfaceContained* contained, Status* status);
+void BEZ_newton_refine_surface(const int* num_nodes, const double* nodes,
+    const int* degree, const double* x_val, const double* y_val,
+    const double* s, const double* t, double* updated_s, double* updated_t);
+void BEZ_locate_point_surface(const int* num_nodes, const double* nodes,
+    const int* degree, const double* x_val, const double* y_val, double* s_val,
+    double* t_val);
+void BEZ_surface_intersections(const int* num_nodes1, const double* nodes1,
+    const int* degree1, const int* num_nodes2, const double* nodes2,
+    const int* degree2, const int* segment_ends_size, int* segment_ends,
+    int* segments_size, CurvedPolygonSegment* segments, int* num_intersected,
+    SurfaceContained* contained, Status* status);
 void BEZ_free_surface_intersections_workspace(void);
 
 #if defined(__cplusplus)

--- a/src/python/bezier/_curve.pxd
+++ b/src/python/bezier/_curve.pxd
@@ -18,37 +18,43 @@ from libcpp cimport bool as bool_t
 
 cdef extern from "bezier/curve.h":
     void evaluate_curve_barycentric "BEZ_evaluate_curve_barycentric" (
-        int* num_nodes, int* dimension, double* nodes,
-        int* num_vals, double* lambda1, double* lambda2, double* evaluated)
+        const int* num_nodes, const int* dimension,
+        const double* nodes, const int* num_vals, const double* lambda1,
+        const double* lambda2, double* evaluated)
     void evaluate_multi "BEZ_evaluate_multi" (
-        int* num_nodes, int* dimension, double* nodes,
-        int* num_vals, double* s_vals, double* evaluated)
+        const int* num_nodes, const int* dimension,
+        const double* nodes, const int* num_vals, const double* s_vals,
+        double* evaluated)
     void specialize_curve "BEZ_specialize_curve" (
-        int* num_nodes, int* dimension, double* nodes,
-        double* start, double* end, double* new_nodes)
+        const int* num_nodes, const int* dimension,
+        const double* nodes, const double* start, const double* end,
+        double* new_nodes)
     void evaluate_hodograph "BEZ_evaluate_hodograph" (
-        double* s, int* num_nodes, int* dimension,
-        double* nodes, double* hodograph)
+        double* s, const int* num_nodes,
+        const int* dimension, const double* nodes, double* hodograph)
     void subdivide_nodes_curve "BEZ_subdivide_nodes_curve" (
-        int* num_nodes, int* dimension, double* nodes,
-        double* left_nodes, double* right_nodes)
+        const int* num_nodes, const int* dimension,
+        const double* nodes, double* left_nodes, double* right_nodes)
     void newton_refine_curve "BEZ_newton_refine_curve" (
-        int* num_nodes, int* dimension, double* nodes,
-        double* point, double* s, double* updated_s)
+        const int* num_nodes, const int* dimension,
+        const double* nodes, const double* point, const double* s,
+        double* updated_s)
     void locate_point_curve "BEZ_locate_point_curve" (
-        int* num_nodes, int* dimension, double* nodes,
-        double* point, double* s_approx)
+        const int* num_nodes, const int* dimension,
+        const double* nodes, const double* point, double* s_approx)
     void elevate_nodes_curve "BEZ_elevate_nodes_curve" (
-        int* num_nodes, int* dimension, double* nodes, double* elevated)
+        const int* num_nodes, const int* dimension,
+        const double* nodes, double* elevated)
     void get_curvature "BEZ_get_curvature" (
-        int* num_nodes, double* nodes, double* tangent_vec,
-        double* s, double* curvature)
+        const int* num_nodes, const double* nodes,
+        const double* tangent_vec, const double* s, double* curvature)
     void reduce_pseudo_inverse "BEZ_reduce_pseudo_inverse" (
-        int* num_nodes, int* dimension, double* nodes,
-        double* reduced, bool_t* not_implemented)
+        const int* num_nodes, const int* dimension,
+        const double* nodes, double* reduced, bool_t* not_implemented)
     void full_reduce "BEZ_full_reduce" (
-        int* num_nodes, int* dimension, double* nodes,
-        int* num_reduced_nodes, double* reduced, bool_t* not_implemented)
+        const int* num_nodes, const int* dimension,
+        const double* nodes, int* num_reduced_nodes, double* reduced,
+        bool_t* not_implemented)
     void compute_length "BEZ_compute_length" (
-        int* num_nodes, int* dimension, double* nodes,
-        double* length, int* error_val)
+        const int* num_nodes, const int* dimension,
+        const double* nodes, double* length, int* error_val)

--- a/src/python/bezier/_curve_intersection.pxd
+++ b/src/python/bezier/_curve_intersection.pxd
@@ -25,15 +25,16 @@ cdef extern from "bezier/curve_intersection.h":
         DISJOINT = 2
 
     void newton_refine_curve_intersect "BEZ_newton_refine_curve_intersect" (
-        double* s, int* num_nodes1, double* nodes1,
-        double* t, int* num_nodes2, double* nodes2, double* new_s, double* new_t,
-        Status* status)
+        const double* s, const int* num_nodes1,
+        const double* nodes1, const double* t, const int* num_nodes2,
+        const double* nodes2, double* new_s, double* new_t, Status* status)
     void bbox_intersect "BEZ_bbox_intersect" (
-        int* num_nodes1, double* nodes1, int* num_nodes2,
-        double* nodes2, BoxIntersectionType* enum_)
+        const int* num_nodes1, const double* nodes1,
+        const int* num_nodes2, const double* nodes2, BoxIntersectionType* enum_)
     void curve_intersections "BEZ_curve_intersections" (
-        int* num_nodes_first, double* nodes_first,
-        int* num_nodes_second, double* nodes_second, int* intersections_size,
-        double* intersections, int* num_intersections, bool_t* coincident,
+        const int* num_nodes_first,
+        const double* nodes_first, const int* num_nodes_second,
+        const double* nodes_second, const int* intersections_size,
+        double* intersections, const int* num_intersections, bool_t* coincident,
         Status* status)
     void free_curve_intersections_workspace "BEZ_free_curve_intersections_workspace" ()

--- a/src/python/bezier/_helpers.pxd
+++ b/src/python/bezier/_helpers.pxd
@@ -18,21 +18,22 @@ from libcpp cimport bool as bool_t
 
 cdef extern from "bezier/helpers.h":
     void cross_product "BEZ_cross_product" (
-        double* vec0, double* vec1, double* result)
+        const double* vec0, const double* vec1, double* result)
     void bbox "BEZ_bbox" (
-        int* num_nodes, double* nodes, double* left, double* right,
-        double* bottom, double* top)
+        const int* num_nodes, const double* nodes, double* left,
+        double* right, double* bottom, double* top)
     void wiggle_interval "BEZ_wiggle_interval" (
-        double* value, double* result, bool_t* success)
+        const double* value, double* result, bool_t* success)
     void contains_nd "BEZ_contains_nd" (
-        int* num_nodes, int* dimension, double* nodes, double* point,
-        bool_t* predicate)
+        const int* num_nodes, const int* dimension,
+        const double* nodes, const double* point, bool_t* predicate)
     bool_t vector_close "BEZ_vector_close" (
-        int* num_values, double* vec1, double* vec2, double* eps)
+        int* num_values, const double* vec1, const double* vec2,
+        const double* eps)
     bool_t in_interval "BEZ_in_interval" (
-        double* value, double* start, double* end)
+        const double* value, const double* start, const double* end)
     void simple_convex_hull "BEZ_simple_convex_hull" (
-        int* num_points, double* points, int* polygon_size, double* polygon)
+        int* num_points, const double* points, int* polygon_size, double* polygon)
     void polygon_collide "BEZ_polygon_collide" (
-        int* polygon_size1, double* polygon1, int* polygon_size2,
-        double* polygon2, bool_t* collision)
+        const int* polygon_size1, const double* polygon1,
+        const int* polygon_size2, const double* polygon2, bool_t* collision)

--- a/src/python/bezier/_surface.pxd
+++ b/src/python/bezier/_surface.pxd
@@ -54,4 +54,4 @@ cdef extern from "bezier/surface.h":
         double* nodes3)
     void compute_area "BEZ_compute_area" (
         int* num_edges, int* sizes,
-        const double** nodes_pointers, double* area, bool_t* not_implemented)
+        const double* const* nodes_pointers, double* area, bool_t* not_implemented)

--- a/src/python/bezier/_surface.pxd
+++ b/src/python/bezier/_surface.pxd
@@ -18,36 +18,40 @@ from libcpp cimport bool as bool_t
 
 cdef extern from "bezier/surface.h":
     void de_casteljau_one_round "BEZ_de_casteljau_one_round" (
-        int* num_nodes, int* dimension, double* nodes,
-        int* degree, double* lambda1, double* lambda2, double* lambda3,
-        double* new_nodes)
+        const int* num_nodes, const int* dimension,
+        const double* nodes, const int* degree, const double* lambda1,
+        const double* lambda2, const double* lambda3, double* new_nodes)
     void evaluate_barycentric "BEZ_evaluate_barycentric" (
-        int* num_nodes, int* dimension, double* nodes,
-        int* degree, double* lambda1, double* lambda2, double* lambda3,
-        double* point)
+        const int* num_nodes, const int* dimension,
+        const double* nodes, const int* degree, const double* lambda1,
+        const double* lambda2, const double* lambda3, double* point)
     void evaluate_barycentric_multi "BEZ_evaluate_barycentric_multi" (
-        int* num_nodes, int* dimension, double* nodes,
-        int* degree, int* num_vals, double* param_vals, double* evaluated)
+        const int* num_nodes, const int* dimension,
+        const double* nodes, const int* degree, const int* num_vals,
+        const double* param_vals, double* evaluated)
     void evaluate_cartesian_multi "BEZ_evaluate_cartesian_multi" (
-        int* num_nodes, int* dimension, double* nodes,
-        int* degree, int* num_vals, double* param_vals, double* evaluated)
+        const int* num_nodes, const int* dimension,
+        const double* nodes, const int* degree, const int* num_vals,
+        const double* param_vals, double* evaluated)
     void jacobian_both "BEZ_jacobian_both" (
-        int* num_nodes, int* dimension, double* nodes, int* degree,
-        double* new_nodes)
+        const int* num_nodes, const int* dimension,
+        const double* nodes, const int* degree, double* new_nodes)
     void jacobian_det "BEZ_jacobian_det" (
-        int* num_nodes, double* nodes, int* degree, int* num_vals,
-        double* param_vals, double* evaluated)
+        const int* num_nodes, const double* nodes,
+        const int* degree, const int* num_vals, const double* param_vals,
+        double* evaluated)
     void specialize_surface "BEZ_specialize_surface" (
-        int* num_nodes, int* dimension, double* nodes,
-        int* degree, double* weights_a, double* weights_b, double* weights_c,
-        double* specialized)
+        const int* num_nodes, const int* dimension,
+        const double* nodes, const int* degree, const double* weights_a,
+        const double* weights_b, const double* weights_c, double* specialized)
     void subdivide_nodes_surface "BEZ_subdivide_nodes_surface" (
-        int* num_nodes, int* dimension, double* nodes,
-        int* degree, double* nodes_a, double* nodes_b, double* nodes_c,
-        double* nodes_d)
+        const int* num_nodes, const int* dimension,
+        const double* nodes, const int* degree, double* nodes_a, double* nodes_b,
+        double* nodes_c, double* nodes_d)
     void compute_edge_nodes "BEZ_compute_edge_nodes" (
-        int* num_nodes, int* dimension, double* nodes,
-        int* degree, double* nodes1, double* nodes2, double* nodes3)
+        const int* num_nodes, const int* dimension,
+        const double* nodes, const int* degree, double* nodes1, double* nodes2,
+        double* nodes3)
     void compute_area "BEZ_compute_area" (
-        int* num_edges, int* sizes, double** nodes_pointers,
-        double* area, bool_t* not_implemented)
+        int* num_edges, int* sizes,
+        const double** nodes_pointers, double* area, bool_t* not_implemented)

--- a/src/python/bezier/_surface_intersection.pxd
+++ b/src/python/bezier/_surface_intersection.pxd
@@ -28,15 +28,17 @@ cdef extern from "bezier/surface_intersection.h":
         int edge_index
 
     void newton_refine_surface "BEZ_newton_refine_surface" (
-        int* num_nodes, double* nodes, int* degree,
-        double* x_val, double* y_val, double* s, double* t, double* updated_s,
-        double* updated_t)
+        const int* num_nodes, const double* nodes,
+        const int* degree, const double* x_val, const double* y_val,
+        const double* s, const double* t, double* updated_s, double* updated_t)
     void locate_point_surface "BEZ_locate_point_surface" (
-        int* num_nodes, double* nodes, int* degree,
-        double* x_val, double* y_val, double* s_val, double* t_val)
+        const int* num_nodes, const double* nodes,
+        const int* degree, const double* x_val, const double* y_val, double* s_val,
+        double* t_val)
     void surface_intersections "BEZ_surface_intersections" (
-        int* num_nodes1, double* nodes1, int* degree1,
-        int* num_nodes2, double* nodes2, int* degree2, int* segment_ends_size,
-        int* segment_ends, int* segments_size, CurvedPolygonSegment* segments,
-        int* num_intersected, SurfaceContained* contained, Status* status)
+        const int* num_nodes1, const double* nodes1,
+        const int* degree1, const int* num_nodes2, const double* nodes2,
+        const int* degree2, const int* segment_ends_size, int* segment_ends,
+        int* segments_size, CurvedPolygonSegment* segments, int* num_intersected,
+        SurfaceContained* contained, Status* status) 
     void free_surface_intersections_workspace "BEZ_free_surface_intersections_workspace" ()


### PR DESCRIPTION
Fixes #168.