### PR TITLE
Removing `get_dll()` helper.

### DIFF
--- a/docs/python/reference/bezier.rst
+++ b/docs/python/reference/bezier.rst
@@ -2,7 +2,7 @@ bezier package
 ==============
 
 .. automodule:: bezier
-    :members: __version__, get_dll
+    :members: __version__
 
 Submodules
 ----------

--- a/src/python/bezier/__init__.py
+++ b/src/python/bezier/__init__.py
@@ -27,10 +27,6 @@ Plotting utilities are also provided.
 .. autoclass:: Surface
 """
 
-import os
-
-import pkg_resources
-
 # NOTE: ``__config__`` **must** be the first import because it (may)
 #       modify the search path used to locate shared libraries.
 from bezier import __config__
@@ -59,30 +55,7 @@ __all__ = [
     "__version__",
     "Curve",
     "CurvedPolygon",
-    "get_dll",
     "Surface",
     "Triangle",
     "UnsupportedDegree",
 ]
-
-
-def get_dll():
-    """Get the directory with the Windows shared library.
-
-    Extension modules (and Cython modules) that need to compile against
-    ``libbezier`` should use this function to locate the appropriate
-    Windows shared library or libraries (DLLs).
-
-    For more information, see :doc:`../binary-extension`.
-
-    Returns:
-        str: ``extra-dll`` directory that contains the Windows shared library
-        for the ``libbezier`` Fortran library.
-
-    Raises:
-        OSError: If this function is used anywhere other than Windows.
-    """
-    if os.name == "nt":
-        return pkg_resources.resource_filename("bezier", "extra-dll")
-
-    raise OSError("This function should only be used on Windows.")

--- a/tests/unit/test___init__.py
+++ b/tests/unit/test___init__.py
@@ -11,17 +11,9 @@
 # limitations under the License.
 
 import email
-import os
 import unittest
-import unittest.mock
 
 import pkg_resources
-
-CHECK_PKG_MSG = """\
-path     = {!r}
-suffix   = {!r}
-site_pkg = {!r}
-from_egg = {!r}"""
 
 
 class Test___version__(unittest.TestCase):
@@ -52,32 +44,3 @@ class Test___author__(unittest.TestCase):
         metadata = distrib.get_metadata(distrib.PKG_INFO)
         installed_author = email.message_from_string(metadata).get("Author")
         self.assertEqual(hardcoded_author, installed_author)
-
-
-class Test_get_dll(unittest.TestCase):
-    @staticmethod
-    def _call_function_under_test():
-        import bezier
-
-        return bezier.get_dll()
-
-    @unittest.mock.patch("os.name", new="nt")
-    def test_windows(self):
-        dll_directory = self._call_function_under_test()
-        _check_pkg_filename(self, dll_directory, "extra-dll")
-
-    @unittest.mock.patch("os.name", new="posix")
-    def test_non_windows(self):
-        with self.assertRaises(OSError):
-            self._call_function_under_test()
-
-
-def _check_pkg_filename(test_case, path, last_segment):
-    short = os.path.join("bezier", last_segment)
-    from_egg = path.endswith(short) and ".egg" in path
-    src_path = os.path.join("src", "python", short)
-    from_source = path.endswith(src_path)
-    verbose = os.path.join("site-packages", short)
-    site_pkg = path.endswith(verbose)
-    msg = CHECK_PKG_MSG.format(path, verbose, site_pkg, from_egg)
-    test_case.assertTrue(from_egg or from_source or site_pkg, msg=msg)


### PR DESCRIPTION
The original goal of this function was to be part of a suite intended to emulate `np.get_include()`, however now that `libbezier` exists and has a usable installation story, this is not necessary. (There is no equivalent `libnumpy`.)