### PR TITLE
Converting console codeblocks to doctest for Linux sections of binary extension.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,8 @@ jobs:
       MATPLOTLIBRC: tests
     steps:
       - checkout
+      - setup_remote_docker:
+          docker_layer_caching: true
       - run:
           name: Check that all Cython generated files have been updated
           command: nox -s "update_generated(check=True)"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,8 +9,7 @@ jobs:
       MATPLOTLIBRC: tests
     steps:
       - checkout
-      - setup_remote_docker:
-          docker_layer_caching: true
+      - setup_remote_docker
       - run:
           name: Check that all Cython generated files have been updated
           command: nox -s "update_generated(check=True)"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,44 +10,44 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker
-      - run:
-          name: Check that all Cython generated files have been updated
-          command: nox -s "update_generated(check=True)"
-      - run:
-          name: Unit tests in Python 3.6
-          command: nox -s "unit-3.6"
-      - run:
-          name: Unit tests in Python 3.7
-          command: nox -s "unit-3.7"
-      - run:
-          name: Unit tests in pypy3
-          command: nox -s "unit-pypy3"
-      - run:
-          name: Unit tests AND line coverage in Python 3.8
-          command: nox -s cover
-      - run:
-          name: Fortran unit tests
-          command: nox -s fortran_unit
-      - run:
-          name: Functional tests in Python 3.8
-          command: nox -s "functional-3.8"
+      # - run:
+      #     name: Check that all Cython generated files have been updated
+      #     command: nox -s "update_generated(check=True)"
+      # - run:
+      #     name: Unit tests in Python 3.6
+      #     command: nox -s "unit-3.6"
+      # - run:
+      #     name: Unit tests in Python 3.7
+      #     command: nox -s "unit-3.7"
+      # - run:
+      #     name: Unit tests in pypy3
+      #     command: nox -s "unit-pypy3"
+      # - run:
+      #     name: Unit tests AND line coverage in Python 3.8
+      #     command: nox -s cover
+      # - run:
+      #     name: Fortran unit tests
+      #     command: nox -s fortran_unit
+      # - run:
+      #     name: Functional tests in Python 3.8
+      #     command: nox -s "functional-3.8"
       - run:
           name: Run all doctests
           command: nox -s doctest
-      - run:
-          name: Build docs
-          command: nox -s docs
-      - run:
-          name: Lint code for style issues
-          command: nox -s lint
-      - run:
-          name: Check that test case examples are valid for JSON schema
-          command: nox -s validate_functional_test_cases
-      - deploy:
-          name: Upload coverage to coveralls
-          command: |
-            .nox/cover/bin/python -m pip install coveralls
-            .nox/cover/bin/coveralls
+      # - run:
+      #     name: Build docs
+      #     command: nox -s docs
+      # - run:
+      #     name: Lint code for style issues
+      #     command: nox -s lint
+      # - run:
+      #     name: Check that test case examples are valid for JSON schema
+      #     command: nox -s validate_functional_test_cases
+      # - deploy:
+      #     name: Upload coverage to coveralls
+      #     command: |
+      #       .nox/cover/bin/python -m pip install coveralls
+      #       .nox/cover/bin/coveralls
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,44 +10,44 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker
-      # - run:
-      #     name: Check that all Cython generated files have been updated
-      #     command: nox -s "update_generated(check=True)"
-      # - run:
-      #     name: Unit tests in Python 3.6
-      #     command: nox -s "unit-3.6"
-      # - run:
-      #     name: Unit tests in Python 3.7
-      #     command: nox -s "unit-3.7"
-      # - run:
-      #     name: Unit tests in pypy3
-      #     command: nox -s "unit-pypy3"
-      # - run:
-      #     name: Unit tests AND line coverage in Python 3.8
-      #     command: nox -s cover
-      # - run:
-      #     name: Fortran unit tests
-      #     command: nox -s fortran_unit
-      # - run:
-      #     name: Functional tests in Python 3.8
-      #     command: nox -s "functional-3.8"
+      - run:
+          name: Check that all Cython generated files have been updated
+          command: nox -s "update_generated(check=True)"
+      - run:
+          name: Unit tests in Python 3.6
+          command: nox -s "unit-3.6"
+      - run:
+          name: Unit tests in Python 3.7
+          command: nox -s "unit-3.7"
+      - run:
+          name: Unit tests in pypy3
+          command: nox -s "unit-pypy3"
+      - run:
+          name: Unit tests AND line coverage in Python 3.8
+          command: nox -s cover
+      - run:
+          name: Fortran unit tests
+          command: nox -s fortran_unit
+      - run:
+          name: Functional tests in Python 3.8
+          command: nox -s "functional-3.8"
       - run:
           name: Run all doctests
           command: nox -s doctest
-      # - run:
-      #     name: Build docs
-      #     command: nox -s docs
-      # - run:
-      #     name: Lint code for style issues
-      #     command: nox -s lint
-      # - run:
-      #     name: Check that test case examples are valid for JSON schema
-      #     command: nox -s validate_functional_test_cases
-      # - deploy:
-      #     name: Upload coverage to coveralls
-      #     command: |
-      #       .nox/cover/bin/python -m pip install coveralls
-      #       .nox/cover/bin/coveralls
+      - run:
+          name: Build docs
+          command: nox -s docs
+      - run:
+          name: Lint code for style issues
+          command: nox -s lint
+      - run:
+          name: Check that test case examples are valid for JSON schema
+          command: nox -s validate_functional_test_cases
+      - deploy:
+          name: Upload coverage to coveralls
+          command: |
+            .nox/cover/bin/python -m pip install coveralls
+            .nox/cover/bin/coveralls
 
 workflows:
   version: 2

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ docs/abi/example
 scripts/macos/dist_wheels/
 scripts/macos/fixed_wheels/
 scripts/macos/test-venv/
+scripts/manylinux/fixed_wheels/
 src/fortran/*.o
 src/fortran/quadpack/*.o
 src/python/bezier/_speedup*.so

--- a/docs/python/binary-extension.rst
+++ b/docs/python/binary-extension.rst
@@ -124,7 +124,7 @@ and the local copy of ``libbezier`` depends on the other dependencies in
    Dynamic section at offset 0x44dd8 contains 28 entries:
      Tag        Type                         Name/Value
     0x0000000000000001 (NEEDED)             Shared library: [libgfortran-2e0d59d6.so.5.0.0]
-    0x0000000000000001 (NEEDED)             Shared library: [libm.so.6]
+    0x0000000000000001 (NEEDED)             Shared library: [libm.so.6--NOPE]
     0x0000000000000001 (NEEDED)             Shared library: [libgcc_s.so.1]
     0x0000000000000001 (NEEDED)             Shared library: [libc.so.6]
     0x000000000000000e (SONAME)             Library soname: [libbezier-28a97ca3.so.2020.1.14]

--- a/docs/python/binary-extension.rst
+++ b/docs/python/binary-extension.rst
@@ -81,7 +81,7 @@ with a modified ``libbezier`` and all of its dependencies (e.g.
    '.../site-packages/bezier/.libs'
    >>> print_tree(libs_directory)
    .libs/
-     libbezier-28a97ca3.so.2020.1.14
+     libbezier-85d21594.so.2020.1.14
      libgfortran-2e0d59d6.so.5.0.0
      libquadmath-2d0c479f.so.0.0.0
      libz-eb09ad1d.so.1.2.3
@@ -101,7 +101,7 @@ The ``bezier._speedup`` module depends on this local copy of ``libbezier``:
    Dynamic section at offset 0x43d000 contains 27 entries:
      Tag        Type                         Name/Value
     0x000000000000000f (RPATH)              Library rpath: [$ORIGIN/.libs]
-    0x0000000000000001 (NEEDED)             Shared library: [libbezier-28a97ca3.so.2020.1.14]
+    0x0000000000000001 (NEEDED)             Shared library: [libbezier-85d21594.so.2020.1.14]
     0x0000000000000001 (NEEDED)             Shared library: [libpthread.so.0]
     0x0000000000000001 (NEEDED)             Shared library: [libc.so.6]
     0x000000000000000c (INIT)               0x9d40
@@ -113,13 +113,13 @@ and the local copy of ``libbezier`` depends on the other dependencies in
 .. testcode:: linux-readelf-lib
    :hide:
 
-   invoke_shell("readelf", "-d", ".libs/libbezier-28a97ca3.so.2020.1.14")
+   invoke_shell("readelf", "-d", ".libs/libbezier-85d21594.so.2020.1.14")
    invoke_shell("readelf", "-d", ".libs/libgfortran-2e0d59d6.so.5.0.0")
 
 .. testoutput:: linux-readelf-lib
    :linux-only:
 
-   $ readelf -d .libs/libbezier-28a97ca3.so.2020.1.14
+   $ readelf -d .libs/libbezier-85d21594.so.2020.1.14
 
    Dynamic section at offset 0x44dd8 contains 28 entries:
      Tag        Type                         Name/Value
@@ -127,7 +127,7 @@ and the local copy of ``libbezier`` depends on the other dependencies in
     0x0000000000000001 (NEEDED)             Shared library: [libm.so.6]
     0x0000000000000001 (NEEDED)             Shared library: [libgcc_s.so.1]
     0x0000000000000001 (NEEDED)             Shared library: [libc.so.6]
-    0x000000000000000e (SONAME)             Library soname: [libbezier-28a97ca3.so.2020.1.14]
+    0x000000000000000e (SONAME)             Library soname: [libbezier-85d21594.so.2020.1.14]
     0x000000000000000c (INIT)               0x2be8
    ...
    $ readelf -d .libs/libgfortran-2e0d59d6.so.5.0.0

--- a/docs/python/binary-extension.rst
+++ b/docs/python/binary-extension.rst
@@ -81,7 +81,7 @@ with a modified ``libbezier`` and all of its dependencies (e.g.
    '.../site-packages/bezier/.libs'
    >>> print_tree(libs_directory)
    .libs/
-     libbezier-85d21594.so.2020.1.14
+     libbezier-28a97ca3.so.2020.1.14
      libgfortran-2e0d59d6.so.5.0.0
      libquadmath-2d0c479f.so.0.0.0
      libz-eb09ad1d.so.1.2.3
@@ -101,7 +101,7 @@ The ``bezier._speedup`` module depends on this local copy of ``libbezier``:
    Dynamic section at offset 0x43d000 contains 27 entries:
      Tag        Type                         Name/Value
     0x000000000000000f (RPATH)              Library rpath: [$ORIGIN/.libs]
-    0x0000000000000001 (NEEDED)             Shared library: [libbezier-85d21594.so.2020.1.14]
+    0x0000000000000001 (NEEDED)             Shared library: [libbezier-28a97ca3.so.2020.1.14]
     0x0000000000000001 (NEEDED)             Shared library: [libpthread.so.0]
     0x0000000000000001 (NEEDED)             Shared library: [libc.so.6]
     0x000000000000000c (INIT)               0x9d40
@@ -113,13 +113,13 @@ and the local copy of ``libbezier`` depends on the other dependencies in
 .. testcode:: linux-readelf-lib
    :hide:
 
-   invoke_shell("readelf", "-d", ".libs/libbezier-85d21594.so.2020.1.14")
+   invoke_shell("readelf", "-d", ".libs/libbezier-28a97ca3.so.2020.1.14")
    invoke_shell("readelf", "-d", ".libs/libgfortran-2e0d59d6.so.5.0.0")
 
 .. testoutput:: linux-readelf-lib
    :linux-only:
 
-   $ readelf -d .libs/libbezier-85d21594.so.2020.1.14
+   $ readelf -d .libs/libbezier-28a97ca3.so.2020.1.14
 
    Dynamic section at offset 0x44dd8 contains 28 entries:
      Tag        Type                         Name/Value
@@ -127,7 +127,7 @@ and the local copy of ``libbezier`` depends on the other dependencies in
     0x0000000000000001 (NEEDED)             Shared library: [libm.so.6]
     0x0000000000000001 (NEEDED)             Shared library: [libgcc_s.so.1]
     0x0000000000000001 (NEEDED)             Shared library: [libc.so.6]
-    0x000000000000000e (SONAME)             Library soname: [libbezier-85d21594.so.2020.1.14]
+    0x000000000000000e (SONAME)             Library soname: [libbezier-28a97ca3.so.2020.1.14]
     0x000000000000000c (INIT)               0x2be8
    ...
    $ readelf -d .libs/libgfortran-2e0d59d6.so.5.0.0

--- a/docs/python/binary-extension.rst
+++ b/docs/python/binary-extension.rst
@@ -124,7 +124,7 @@ and the local copy of ``libbezier`` depends on the other dependencies in
    Dynamic section at offset 0x44dd8 contains 28 entries:
      Tag        Type                         Name/Value
     0x0000000000000001 (NEEDED)             Shared library: [libgfortran-2e0d59d6.so.5.0.0]
-    0x0000000000000001 (NEEDED)             Shared library: [libm.so.6--NOPE]
+    0x0000000000000001 (NEEDED)             Shared library: [libm.so.6]
     0x0000000000000001 (NEEDED)             Shared library: [libgcc_s.so.1]
     0x0000000000000001 (NEEDED)             Shared library: [libc.so.6]
     0x000000000000000e (SONAME)             Library soname: [libbezier-28a97ca3.so.2020.1.14]

--- a/docs/python/binary-extension.rst.template
+++ b/docs/python/binary-extension.rst.template
@@ -81,7 +81,7 @@ with a modified ``libbezier`` and all of its dependencies (e.g.
    '.../site-packages/bezier/.libs'
    >>> print_tree(libs_directory)
    .libs/
-     libbezier-28a97ca3.so.2020.1.14
+     libbezier-85d21594.so.2020.1.14
      libgfortran-2e0d59d6.so.5.0.0
      libquadmath-2d0c479f.so.0.0.0
      libz-eb09ad1d.so.1.2.3
@@ -101,7 +101,7 @@ The ``bezier._speedup`` module depends on this local copy of ``libbezier``:
    Dynamic section at offset 0x43d000 contains 27 entries:
      Tag        Type                         Name/Value
     0x000000000000000f (RPATH)              Library rpath: [$ORIGIN/.libs]
-    0x0000000000000001 (NEEDED)             Shared library: [libbezier-28a97ca3.so.2020.1.14]
+    0x0000000000000001 (NEEDED)             Shared library: [libbezier-85d21594.so.2020.1.14]
     0x0000000000000001 (NEEDED)             Shared library: [libpthread.so.0]
     0x0000000000000001 (NEEDED)             Shared library: [libc.so.6]
     0x000000000000000c (INIT)               0x9d40
@@ -113,13 +113,13 @@ and the local copy of ``libbezier`` depends on the other dependencies in
 .. testcode:: linux-readelf-lib
    :hide:
 
-   invoke_shell("readelf", "-d", ".libs/libbezier-28a97ca3.so.2020.1.14")
+   invoke_shell("readelf", "-d", ".libs/libbezier-85d21594.so.2020.1.14")
    invoke_shell("readelf", "-d", ".libs/libgfortran-2e0d59d6.so.5.0.0")
 
 .. testoutput:: linux-readelf-lib
    :linux-only:
 
-   $ readelf -d .libs/libbezier-28a97ca3.so.2020.1.14
+   $ readelf -d .libs/libbezier-85d21594.so.2020.1.14
 
    Dynamic section at offset 0x44dd8 contains 28 entries:
      Tag        Type                         Name/Value
@@ -127,7 +127,7 @@ and the local copy of ``libbezier`` depends on the other dependencies in
     0x0000000000000001 (NEEDED)             Shared library: [libm.so.6]
     0x0000000000000001 (NEEDED)             Shared library: [libgcc_s.so.1]
     0x0000000000000001 (NEEDED)             Shared library: [libc.so.6]
-    0x000000000000000e (SONAME)             Library soname: [libbezier-28a97ca3.so.2020.1.14]
+    0x000000000000000e (SONAME)             Library soname: [libbezier-85d21594.so.2020.1.14]
     0x000000000000000c (INIT)               0x2be8
    ...
    $ readelf -d .libs/libgfortran-2e0d59d6.so.5.0.0

--- a/docs/python/binary-extension.rst.template
+++ b/docs/python/binary-extension.rst.template
@@ -81,7 +81,7 @@ with a modified ``libbezier`` and all of its dependencies (e.g.
    '.../site-packages/bezier/.libs'
    >>> print_tree(libs_directory)
    .libs/
-     libbezier-85d21594.so.2020.1.14
+     libbezier-28a97ca3.so.2020.1.14
      libgfortran-2e0d59d6.so.5.0.0
      libquadmath-2d0c479f.so.0.0.0
      libz-eb09ad1d.so.1.2.3
@@ -101,7 +101,7 @@ The ``bezier._speedup`` module depends on this local copy of ``libbezier``:
    Dynamic section at offset 0x43d000 contains 27 entries:
      Tag        Type                         Name/Value
     0x000000000000000f (RPATH)              Library rpath: [$ORIGIN/.libs]
-    0x0000000000000001 (NEEDED)             Shared library: [libbezier-85d21594.so.2020.1.14]
+    0x0000000000000001 (NEEDED)             Shared library: [libbezier-28a97ca3.so.2020.1.14]
     0x0000000000000001 (NEEDED)             Shared library: [libpthread.so.0]
     0x0000000000000001 (NEEDED)             Shared library: [libc.so.6]
     0x000000000000000c (INIT)               0x9d40
@@ -113,21 +113,21 @@ and the local copy of ``libbezier`` depends on the other dependencies in
 .. testcode:: linux-readelf-lib
    :hide:
 
-   invoke_shell("readelf", "-d", ".libs/libbezier-85d21594.so.2020.1.14")
+   invoke_shell("readelf", "-d", ".libs/libbezier-28a97ca3.so.2020.1.14")
    invoke_shell("readelf", "-d", ".libs/libgfortran-2e0d59d6.so.5.0.0")
 
 .. testoutput:: linux-readelf-lib
    :linux-only:
 
-   $ readelf -d .libs/libbezier-85d21594.so.2020.1.14
+   $ readelf -d .libs/libbezier-28a97ca3.so.2020.1.14
 
    Dynamic section at offset 0x44dd8 contains 28 entries:
      Tag        Type                         Name/Value
     0x0000000000000001 (NEEDED)             Shared library: [libgfortran-2e0d59d6.so.5.0.0]
-    0x0000000000000001 (NEEDED)             Shared library: [libm.so.6]
+    0x0000000000000001 (NEEDED)             Shared library: [libm.so.6--NOPE]
     0x0000000000000001 (NEEDED)             Shared library: [libgcc_s.so.1]
     0x0000000000000001 (NEEDED)             Shared library: [libc.so.6]
-    0x000000000000000e (SONAME)             Library soname: [libbezier-85d21594.so.2020.1.14]
+    0x000000000000000e (SONAME)             Library soname: [libbezier-28a97ca3.so.2020.1.14]
     0x000000000000000c (INIT)               0x2be8
    ...
    $ readelf -d .libs/libgfortran-2e0d59d6.so.5.0.0

--- a/docs/python/binary-extension.rst.template
+++ b/docs/python/binary-extension.rst.template
@@ -49,18 +49,52 @@ The command line tool `auditwheel`_ adds a ``bezier/.libs`` directory
 with a modified ``libbezier`` and all of its dependencies (e.g.
 ``libgfortran``)
 
-.. code-block:: console
+.. testsetup:: linux-libs, linux-readelf-py, linux-readelf-lib, macos-dylibs,
+               macos-extension, macos-delocated-libgfortran
 
-   $ cd .../site-packages/bezier
-   $ ls -1 -F .libs/
-   libbezier-4f59b4c5.so.2020.1.14*
-   libgfortran-2e0d59d6.so.5.0.0*
-   libquadmath-2d0c479f.so.0.0.0*
-   libz-eb09ad1d.so.1.2.3*
+   import os
+   import subprocess
+
+   import bezier
+   import tests.utils
+
+
+   print_tree = tests.utils.print_tree
+   base_dir = os.path.abspath(os.path.dirname(bezier.__file__))
+   # macOS specific.
+   dylibs_directory = os.path.join(base_dir, ".dylibs")
+   # Linux specific.
+   libs_directory = os.path.join(base_dir, ".libs")
+
+
+   def invoke_shell(*args):
+       print("$ " + " ".join(args))
+       # NOTE: We print to the stdout of the doctest, rather than using
+       #       ``subprocess.call()`` directly.
+       output_bytes = subprocess.check_output(args, cwd=base_dir)
+       print(output_bytes.decode("utf-8"), end="")
+
+.. doctest:: linux-libs
+   :linux-only:
+
+   >>> libs_directory
+   '.../site-packages/bezier/.libs'
+   >>> print_tree(libs_directory)
+   .libs/
+     libbezier-85d21594.so.2020.1.14
+     libgfortran-2e0d59d6.so.5.0.0
+     libquadmath-2d0c479f.so.0.0.0
+     libz-eb09ad1d.so.1.2.3
 
 The ``bezier._speedup`` module depends on this local copy of ``libbezier``:
 
-.. code-block:: console
+.. testcode:: linux-readelf-py
+   :hide:
+
+   invoke_shell("readelf", "-d", "_speedup.cpython-38-x86_64-linux-gnu.so")
+
+.. testoutput:: linux-readelf-py
+   :linux-only:
 
    $ readelf -d _speedup.cpython-38-x86_64-linux-gnu.so
 
@@ -76,7 +110,14 @@ The ``bezier._speedup`` module depends on this local copy of ``libbezier``:
 and the local copy of ``libbezier`` depends on the other dependencies in
 ``.libs/`` (both directly and indirectly):
 
-.. code-block:: console
+.. testcode:: linux-readelf-lib
+   :hide:
+
+   invoke_shell("readelf", "-d", ".libs/libbezier-85d21594.so.2020.1.14")
+   invoke_shell("readelf", "-d", ".libs/libgfortran-2e0d59d6.so.5.0.0")
+
+.. testoutput:: linux-readelf-lib
+   :linux-only:
 
    $ readelf -d .libs/libbezier-85d21594.so.2020.1.14
 
@@ -115,28 +156,6 @@ macOS
 The command line tool `delocate`_ adds a ``bezier/.dylibs`` directory
 with copies of ``libbezier``, ``libgfortran``, ``libquadmath`` and
 ``libgcc_s``:
-
-.. testsetup:: macos-dylibs, macos-extension, macos-delocated-libgfortran
-
-   import os
-   import subprocess
-
-   import bezier
-   import tests.utils
-
-
-   print_tree = tests.utils.print_tree
-   base_dir = os.path.abspath(os.path.dirname(bezier.__file__))
-   # macOS specific.
-   dylibs_directory = os.path.join(base_dir, ".dylibs")
-
-
-   def invoke_shell(*args):
-       print("$ " + " ".join(args))
-       # NOTE: We print to the stdout of the doctest, rather than using
-       #       ``subprocess.call()`` directly.
-       output_bytes = subprocess.check_output(args, cwd=base_dir)
-       print(output_bytes.decode("utf-8"), end="")
 
 .. doctest:: macos-dylibs
    :macos-only:

--- a/docs/python/binary-extension.rst.template
+++ b/docs/python/binary-extension.rst.template
@@ -81,7 +81,7 @@ with a modified ``libbezier`` and all of its dependencies (e.g.
    '.../site-packages/bezier/.libs'
    >>> print_tree(libs_directory)
    .libs/
-     libbezier-85d21594.so.2020.1.14
+     libbezier-28a97ca3.so.2020.1.14
      libgfortran-2e0d59d6.so.5.0.0
      libquadmath-2d0c479f.so.0.0.0
      libz-eb09ad1d.so.1.2.3
@@ -101,7 +101,7 @@ The ``bezier._speedup`` module depends on this local copy of ``libbezier``:
    Dynamic section at offset 0x43d000 contains 27 entries:
      Tag        Type                         Name/Value
     0x000000000000000f (RPATH)              Library rpath: [$ORIGIN/.libs]
-    0x0000000000000001 (NEEDED)             Shared library: [libbezier-85d21594.so.2020.1.14]
+    0x0000000000000001 (NEEDED)             Shared library: [libbezier-28a97ca3.so.2020.1.14]
     0x0000000000000001 (NEEDED)             Shared library: [libpthread.so.0]
     0x0000000000000001 (NEEDED)             Shared library: [libc.so.6]
     0x000000000000000c (INIT)               0x9d40
@@ -113,13 +113,13 @@ and the local copy of ``libbezier`` depends on the other dependencies in
 .. testcode:: linux-readelf-lib
    :hide:
 
-   invoke_shell("readelf", "-d", ".libs/libbezier-85d21594.so.2020.1.14")
+   invoke_shell("readelf", "-d", ".libs/libbezier-28a97ca3.so.2020.1.14")
    invoke_shell("readelf", "-d", ".libs/libgfortran-2e0d59d6.so.5.0.0")
 
 .. testoutput:: linux-readelf-lib
    :linux-only:
 
-   $ readelf -d .libs/libbezier-85d21594.so.2020.1.14
+   $ readelf -d .libs/libbezier-28a97ca3.so.2020.1.14
 
    Dynamic section at offset 0x44dd8 contains 28 entries:
      Tag        Type                         Name/Value
@@ -127,7 +127,7 @@ and the local copy of ``libbezier`` depends on the other dependencies in
     0x0000000000000001 (NEEDED)             Shared library: [libm.so.6]
     0x0000000000000001 (NEEDED)             Shared library: [libgcc_s.so.1]
     0x0000000000000001 (NEEDED)             Shared library: [libc.so.6]
-    0x000000000000000e (SONAME)             Library soname: [libbezier-85d21594.so.2020.1.14]
+    0x000000000000000e (SONAME)             Library soname: [libbezier-28a97ca3.so.2020.1.14]
     0x000000000000000c (INIT)               0x2be8
    ...
    $ readelf -d .libs/libgfortran-2e0d59d6.so.5.0.0

--- a/docs/python/binary-extension.rst.template
+++ b/docs/python/binary-extension.rst.template
@@ -124,7 +124,7 @@ and the local copy of ``libbezier`` depends on the other dependencies in
    Dynamic section at offset 0x44dd8 contains 28 entries:
      Tag        Type                         Name/Value
     0x0000000000000001 (NEEDED)             Shared library: [libgfortran-2e0d59d6.so.5.0.0]
-    0x0000000000000001 (NEEDED)             Shared library: [libm.so.6--NOPE]
+    0x0000000000000001 (NEEDED)             Shared library: [libm.so.6]
     0x0000000000000001 (NEEDED)             Shared library: [libgcc_s.so.1]
     0x0000000000000001 (NEEDED)             Shared library: [libc.so.6]
     0x000000000000000e (SONAME)             Library soname: [libbezier-28a97ca3.so.2020.1.14]

--- a/noxfile.py
+++ b/noxfile.py
@@ -24,6 +24,7 @@ import py.path
 nox.options.error_on_external_run = True
 nox.options.error_on_missing_interpreters = True
 
+IS_LINUX = sys.platform in ("linux", "linux2")
 IS_MACOS = sys.platform == "darwin"
 IS_WINDOWS = os.name == "nt"
 DEPS = {
@@ -243,6 +244,10 @@ def doctest(session):
         command = get_path("scripts", "macos", "nox-install-for-doctest.sh")
         env = {INSTALL_PREFIX_ENV: install_prefix}
         session.run(command, external=True, env=env)
+    elif IS_LINUX:
+        command = get_path("scripts", "nox-install-for-doctest-linux.sh")
+        session.run(command, external=True)
+        install_prefix = _cmake(session, BUILD_TYPE_RELEASE)
     else:
         install_prefix = install_bezier(session)
     # Run the script for building docs and running doctests.
@@ -560,6 +565,7 @@ def clean(session):
         get_path("scripts", "macos", "dist_wheels"),
         get_path("scripts", "macos", "fixed_wheels"),
         get_path("scripts", "macos", "test-venv"),
+        get_path("scripts", "manylinux", "fixed_wheels"),
         get_path("src", "python", "bezier.egg-info"),
         get_path("src", "python", "bezier", "__pycache__"),
         get_path("src", "python", "bezier", "extra-dll"),

--- a/scripts/docker/README.md
+++ b/scripts/docker/README.md
@@ -13,6 +13,7 @@ This repository is intended to be used as a fully-functional environment for ins
 - `nox` test runner
 - `lcov` line coverage tool
 - `libatlas-base-dev`, `libblas-dev` and `liblapack-dev` (needed by SciPy)
+- `docker` for running the Docker CLI (assuming `/var/run/docker.sock` has been shared from the host OS)
 
 ## Commands
 
@@ -25,17 +26,18 @@ for those who don't use `docker` on a regular basis).
 
 ```
 $ docker build \
->   --file bezier.Dockerfile \
->   --tag dhermes/bezier:latest \
->   .
+>     --file bezier.Dockerfile \
+>     --tag dhermes/bezier:latest \
+>     .
 $ docker run \
->   --rm \
->   --tty \
->   --interactive \
->   --volume $(git rev-parse --show-toplevel):/var/code/bezier/ \
->   --workdir /var/code/bezier/ \
->   dhermes/bezier:latest \
->   /bin/bash
+>     --rm \
+>     --tty \
+>     --interactive \
+>     --volume /var/run/docker.sock:/var/run/docker.sock \
+>     --volume $(git rev-parse --show-toplevel):/var/code/bezier/ \
+>     --workdir /var/code/bezier/ \
+>     dhermes/bezier:latest \
+>     /bin/bash
 ```
 
 ### Generic

--- a/scripts/docker/bezier.Dockerfile
+++ b/scripts/docker/bezier.Dockerfile
@@ -42,3 +42,26 @@ RUN set -ex \
   && pypy3-env/bin/python -m pip install ${WHEELHOUSE}/numpy*.whl \
   && pypy3-env/bin/python -m pip wheel --wheel-dir=${WHEELHOUSE} "scipy == 1.3.3" \
   && rm -fr pypy3-env
+
+# Install Docker CLI (used to build `manylinux` wheel for `nox -s doctest`).
+# Via: https://docs.docker.com/install/linux/docker-ce/ubuntu/
+# Includes a diagnostic-only use of `apt-key fingerprint`.
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+    apt-transport-https \
+    ca-certificates \
+    curl \
+    gnupg-agent \
+    software-properties-common \
+  && curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - \
+  && apt-key fingerprint 0EBFCD88 \
+  && add-apt-repository \
+    "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
+    $(lsb_release -cs) \
+    stable" \
+  && apt-get update \
+  && apt-get install -y docker-ce-cli \
+  && apt-get clean autoclean \
+  && apt-get autoremove -y \
+  && rm -rf /var/lib/apt/lists/* \
+  && rm -f /var/cache/apt/archives/*.deb

--- a/scripts/macos/nox-install-for-doctest.sh
+++ b/scripts/macos/nox-install-for-doctest.sh
@@ -20,19 +20,21 @@ python -m pip install --upgrade delocate
 # 1. Build the wheel from source.
 BASIC_DIR=$(mktemp -d)
 # NOTE: ``pip wheel`` requires ``BEZIER_INSTALL_PREFIX`` to be set.
-python -m pip wheel . --wheel-dir ${BASIC_DIR}
+python -m pip wheel . --wheel-dir "${BASIC_DIR}"
 
 # 2. "delocate" the built wheel.
 DELOCATED_DIR=$(mktemp -d)
 # NOTE: This intentionally does not use ``--check-archs``.
 delocate-wheel \
-    --wheel-dir ${DELOCATED_DIR} \
+    --wheel-dir "${DELOCATED_DIR}" \
     --verbose \
-    ${BASIC_DIR}/bezier*.whl
+    "${BASIC_DIR}"/bezier*.whl
 
 # 3. Install from the "delocated" wheel.
-python -m pip install ${DELOCATED_DIR}/bezier*.whl
+python -m pip install bezier \
+    --no-index \
+    --find-links "${DELOCATED_DIR}"
 
 # 4. Clean up temporary directories.
-rm -fr ${BASIC_DIR}
-rm -fr ${DELOCATED_DIR}
+rm -fr "${BASIC_DIR}"
+rm -fr "${DELOCATED_DIR}"

--- a/scripts/manylinux/build-wheel-for-doctest.sh
+++ b/scripts/manylinux/build-wheel-for-doctest.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e -x
+
+if [[ -z "${PY_ROOT}" ]]; then
+    echo "PY_ROOT environment variable should be set by the caller."
+    exit 1
+fi
+
+if [[ -z "${WHEELHOUSE}" ]]; then
+    echo "WHEELHOUSE environment variable should be set by the caller."
+    exit 1
+fi
+
+if [[ -z "${BEZIER_ROOT}" ]]; then
+    echo "BEZIER_ROOT environment variable should be set by the caller."
+    exit 1
+fi
+
+# 0. Install the Python dependencies
+"${PY_ROOT}/bin/python" -m pip install --upgrade pip
+"${PY_ROOT}/bin/python" -m pip install --upgrade auditwheel "cmake >= 3.15.3" numpy
+
+# 1. Build and install ``libbezier`` into a custom location.
+BUILD_DIR=$(mktemp -d)
+INSTALL_PREFIX=$(mktemp -d)
+mkdir -p "${BUILD_DIR}"
+"${PY_ROOT}/bin/cmake" \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX:PATH="${INSTALL_PREFIX}" \
+    -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON \
+    -DTARGET_NATIVE_ARCH:BOOL=OFF \
+    -S "${BEZIER_ROOT}/src/fortran/" \
+    -B "${BUILD_DIR}"
+"${PY_ROOT}/bin/cmake" \
+    --build "${BUILD_DIR}" \
+    --config Release \
+    --target install
+"${PY_ROOT}/bin/cmake" -L "${BUILD_DIR}"
+
+# 2. Build the wheel
+DIST_WHEELS=$(mktemp -d)
+BEZIER_INSTALL_PREFIX="${INSTALL_PREFIX}" "${PY_ROOT}/bin/python" -m pip wheel \
+    "${BEZIER_ROOT}" \
+    --wheel-dir "${DIST_WHEELS}"
+
+# 3. "repair" the built wheel.
+# NOTE: This will **fail** if not run on a ``manylinux`` compatible Linux.
+auditwheel repair \
+    --wheel-dir "${WHEELHOUSE}" \
+    "${DIST_WHEELS}"/bezier*.whl
+
+# 4. Clean up temporary directories.
+rm -fr "${BUILD_DIR}"
+rm -fr "${INSTALL_PREFIX}"
+rm -fr "${DIST_WHEELS}"

--- a/scripts/nox-install-for-doctest-linux.sh
+++ b/scripts/nox-install-for-doctest-linux.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e -x
+
+# NOTE: This is assumed to be running within an activated virtual environment.
+if [[ "$(python -c 'import sys; print(".".join(map(str, sys.version_info[:2])))')" != "3.8" ]]; then
+    echo "Python 3.8 required."
+    exit 1
+fi
+
+SCRIPT_FI=$(readlink -f ${0})
+SCRIPTS_DIR=$(dirname ${SCRIPT_FI})
+REPO_ROOT=$(dirname ${SCRIPTS_DIR})
+LOCAL_WHEELHOUSE="${REPO_ROOT}/scripts/manylinux/fixed_wheels"
+# Variables within the container.
+PY_ROOT="/opt/python/cp38-cp38"
+BEZIER_ROOT="${REPO_ROOT}"
+WHEELHOUSE="${BEZIER_ROOT}/scripts/manylinux/fixed_wheels"
+
+# 0. Build the `manylinux` wheel (repaired with `auditwheel`).
+CURRENT_CONTAINER_ID=$(docker ps --no-trunc --filter "id=$(hostname)" --format '{{ .ID }}')
+if [[ "$(echo "${CURRENT_CONTAINER_ID}" | wc -w)" == "1" ]]; then
+    # Invoking `docker run` within a container.
+    VOLUME_ARG="--volumes-from=${CURRENT_CONTAINER_ID}"
+else
+    # Running on host
+    VOLUME_ARG="--volume=${REPO_ROOT}:${BEZIER_ROOT}"
+fi
+
+docker run \
+    --rm \
+    --env PY_ROOT="${PY_ROOT}" \
+    --env WHEELHOUSE="${WHEELHOUSE}" \
+    --env BEZIER_ROOT="${BEZIER_ROOT}" \
+    "${VOLUME_ARG}" \
+    quay.io/pypa/manylinux2010_x86_64 \
+    "${BEZIER_ROOT}/scripts/manylinux/build-wheel-for-doctest.sh"
+
+# 1. Install the `manylinux` wheel
+python -m pip install bezier \
+    --no-index \
+    --find-links "${LOCAL_WHEELHOUSE}"

--- a/scripts/nox-install-for-doctest-linux.sh
+++ b/scripts/nox-install-for-doctest-linux.sh
@@ -36,7 +36,7 @@ hostname  # Diagnostic
 env | grep -v COVERALLS_REPO_TOKEN # Diagnostic
 if [[ "${CI}" == "true" ]]; then
     # Create a dummy container which will hold a volume with config.
-    docker create --volume "${BEZIER_ROOT}" --name bezier-manylinux quay.io/pypa/manylinux2010_x86_64 /bin/true
+    docker create --name bezier-manylinux quay.io/pypa/manylinux2010_x86_64 /bin/true
     # Copy a config file into this volume.
     docker cp "${REPO_ROOT}" bezier-manylinux:"${BEZIER_ROOT}"
     # Rely on this dummy container.

--- a/scripts/nox-install-for-doctest-linux.sh
+++ b/scripts/nox-install-for-doctest-linux.sh
@@ -36,7 +36,7 @@ hostname  # Diagnostic
 env | grep -v COVERALLS_REPO_TOKEN # Diagnostic
 if [[ "${CI}" == "true" ]]; then
     # Create a dummy container which will hold a volume with config.
-    docker create --name bezier-manylinux quay.io/pypa/manylinux2010_x86_64 /bin/true
+    docker create --volume "$(dirname "${BEZIER_ROOT}")" --name bezier-manylinux quay.io/pypa/manylinux2010_x86_64 /bin/true
     # Copy a config file into this volume.
     docker cp "${REPO_ROOT}" bezier-manylinux:"${BEZIER_ROOT}"
     # Rely on this dummy container.

--- a/scripts/nox-install-for-doctest-linux.sh
+++ b/scripts/nox-install-for-doctest-linux.sh
@@ -24,31 +24,29 @@ SCRIPT_FI=$(readlink -f ${0})
 SCRIPTS_DIR=$(dirname ${SCRIPT_FI})
 REPO_ROOT=$(dirname ${SCRIPTS_DIR})
 LOCAL_WHEELHOUSE="${REPO_ROOT}/scripts/manylinux/fixed_wheels"
+DOCKER_IMAGE=quay.io/pypa/manylinux2010_x86_64
+DUMMY_IMAGE_NAME=bezier-manylinux
 # Variables within the container.
 PY_ROOT="/opt/python/cp38-cp38"
 BEZIER_ROOT="${REPO_ROOT}"
 WHEELHOUSE="${BEZIER_ROOT}/scripts/manylinux/fixed_wheels"
 
 # 0. Build the `manylinux` wheel (repaired with `auditwheel`).
-docker ps  # Diagnostic
-docker ps --no-trunc  # Diagnostic
-hostname  # Diagnostic
-env | grep -v COVERALLS_REPO_TOKEN # Diagnostic
 if [[ "${CI}" == "true" ]]; then
-    # Create a dummy container which will hold a volume with config.
-    docker create --volume "$(dirname "${BEZIER_ROOT}")" --name bezier-manylinux quay.io/pypa/manylinux2010_x86_64 /bin/true
+    # See: https://circleci.com/docs/2.0/building-docker-images/#mounting-folders
+    # Create a dummy container which will hold a volume.
+    docker create --volume "$(dirname "${BEZIER_ROOT}")" --name "${DUMMY_IMAGE_NAME}" "${DOCKER_IMAGE}" /bin/true
     # Copy source tree into this volume.
-    docker cp "${REPO_ROOT}" bezier-manylinux:"${BEZIER_ROOT}"
+    docker cp "${REPO_ROOT}" "${DUMMY_IMAGE_NAME}":"${BEZIER_ROOT}"
     # Rely on this dummy container.
-    VOLUME_ARG="--volumes-from=bezier-manylinux"
-    docker ps --all  # Diagnositc
+    VOLUME_ARG="--volumes-from=${DUMMY_IMAGE_NAME}"
 else
     CURRENT_CONTAINER_ID=$(docker ps --no-trunc --filter "id=$(hostname)" --format '{{ .ID }}')
     if [[ "$(echo "${CURRENT_CONTAINER_ID}" | wc -w)" == "1" ]]; then
         # Invoking `docker run` within a container.
         VOLUME_ARG="--volumes-from=${CURRENT_CONTAINER_ID}"
     else
-        # Running on host
+        # Running on host.
         VOLUME_ARG="--volume=${REPO_ROOT}:${BEZIER_ROOT}"
     fi
 fi
@@ -59,13 +57,12 @@ docker run \
     --env WHEELHOUSE="${WHEELHOUSE}" \
     --env BEZIER_ROOT="${BEZIER_ROOT}" \
     "${VOLUME_ARG}" \
-    quay.io/pypa/manylinux2010_x86_64 \
+    "${DOCKER_IMAGE}" \
     "${BEZIER_ROOT}/scripts/manylinux/build-wheel-for-doctest.sh"
 
 if [[ "${CI}" == "true" ]]; then
-    # Copy built wheels back into this container.
-    docker cp bezier-manylinux:"${LOCAL_WHEELHOUSE}" "${LOCAL_WHEELHOUSE}"
-    ls -alFG "${LOCAL_WHEELHOUSE}"  # Diagnostic
+    # Copy built wheel(s) back into this container.
+    docker cp "${DUMMY_IMAGE_NAME}":"${WHEELHOUSE}" "${LOCAL_WHEELHOUSE}"
 fi
 
 # 1. Install the `manylinux` wheel

--- a/scripts/nox-install-for-doctest-linux.sh
+++ b/scripts/nox-install-for-doctest-linux.sh
@@ -37,7 +37,7 @@ env | grep -v COVERALLS_REPO_TOKEN # Diagnostic
 if [[ "${CI}" == "true" ]]; then
     # Create a dummy container which will hold a volume with config.
     docker create --volume "$(dirname "${BEZIER_ROOT}")" --name bezier-manylinux quay.io/pypa/manylinux2010_x86_64 /bin/true
-    # Copy a config file into this volume.
+    # Copy source tree into this volume.
     docker cp "${REPO_ROOT}" bezier-manylinux:"${BEZIER_ROOT}"
     # Rely on this dummy container.
     VOLUME_ARG="--volumes-from=bezier-manylinux"
@@ -61,6 +61,12 @@ docker run \
     "${VOLUME_ARG}" \
     quay.io/pypa/manylinux2010_x86_64 \
     "${BEZIER_ROOT}/scripts/manylinux/build-wheel-for-doctest.sh"
+
+if [[ "${CI}" == "true" ]]; then
+    # Copy built wheels back into this container.
+    docker cp bezier-manylinux:"${LOCAL_WHEELHOUSE}" "${LOCAL_WHEELHOUSE}"
+    ls -alFG "${LOCAL_WHEELHOUSE}"  # Diagnostic
+fi
 
 # 1. Install the `manylinux` wheel
 python -m pip install bezier \

--- a/scripts/nox-install-for-doctest-linux.sh
+++ b/scripts/nox-install-for-doctest-linux.sh
@@ -30,6 +30,9 @@ BEZIER_ROOT="${REPO_ROOT}"
 WHEELHOUSE="${BEZIER_ROOT}/scripts/manylinux/fixed_wheels"
 
 # 0. Build the `manylinux` wheel (repaired with `auditwheel`).
+docker ps  # Diagnostic
+docker ps --no-trunc  # Diagnostic
+hostname  # Diagnostic
 CURRENT_CONTAINER_ID=$(docker ps --no-trunc --filter "id=$(hostname)" --format '{{ .ID }}')
 if [[ "$(echo "${CURRENT_CONTAINER_ID}" | wc -w)" == "1" ]]; then
     # Invoking `docker run` within a container.

--- a/scripts/nox-install-for-doctest-linux.sh
+++ b/scripts/nox-install-for-doctest-linux.sh
@@ -44,12 +44,12 @@ if [[ "${CI}" == "true" || "$(echo "${CURRENT_CONTAINER_ID}" | wc -w)" == "1" ]]
     # Copy source tree into this volume.
     docker cp "${REPO_ROOT}" "${DUMMY_IMAGE_NAME}":"${BEZIER_ROOT}"
     # Rely on this dummy container.
-    SRC_VOLUME_ARG="--volumes-from=${DUMMY_IMAGE_NAME}"
-    WHEELHOUSE_VOLUME_ARG=""
+    VOLUME_ARGS=("--volumes-from=${DUMMY_IMAGE_NAME}")
+    VOLUME_COPY="yes"
 else
     # Running on host.
-    SRC_VOLUME_ARG="--volume=${REPO_ROOT}:${BEZIER_ROOT}"
-    WHEELHOUSE_VOLUME_ARG="--volume=${LOCAL_WHEELHOUSE}:${WHEELHOUSE}"
+    VOLUME_ARGS=("--volume=${REPO_ROOT}:${BEZIER_ROOT}", "--volume=${LOCAL_WHEELHOUSE}:${WHEELHOUSE}")
+    VOLUME_COPY="no"
 fi
 
 docker run \
@@ -57,12 +57,11 @@ docker run \
     --env PY_ROOT="${PY_ROOT}" \
     --env WHEELHOUSE="${WHEELHOUSE}" \
     --env BEZIER_ROOT="${BEZIER_ROOT}" \
-    "${SRC_VOLUME_ARG}" \
-    "${WHEELHOUSE_VOLUME_ARG}" \
+    "${VOLUME_ARGS[@]}" \
     "${DOCKER_IMAGE}" \
     "${BEZIER_ROOT}/scripts/manylinux/build-wheel-for-doctest.sh"
 
-if [[ "${WHEELHOUSE_VOLUME_ARG}" == "" ]]; then
+if [[ "${VOLUME_COPY}" == "yes" ]]; then
     # Copy built wheel(s) back into this container.
     docker cp "${DUMMY_IMAGE_NAME}":"${WHEELHOUSE}" "${LOCAL_WHEELHOUSE}"
 fi


### PR DESCRIPTION
This is **almost certainly** more trouble than it's worth. To get this working "correctly" the `doctest` has to be able to install a wheel created in the `manylinux` container (i.e. with an "old enough" `libc`). This is bad enough on a host OS during local dev, but on CircleCI, this requires docker-in-docker (which luckily isn't too challenging since `/var/run/docker.sock` can be shared, but still a lot of machinery without much benefit).

However, what **ultimately** may shoot this down is the fact that the hash on `libbezier-*.so` produced by `auditwheel` (which is just the first 8 characters of the SHA256 checksum of the `.so` file, references [1][1] and [2][2]) seems to be non-deterministic.

[1]: https://github.com/pypa/auditwheel/blob/d5cd0f670eecf9a94be67911e18d3c2dea8ffc55/auditwheel/repair.py#L127
[2]: https://github.com/pypa/auditwheel/blob/d5cd0f670eecf9a94be67911e18d3c2dea8ffc55/auditwheel/hashfile.py#L4-L11