### PR TITLE
Avoiding `bezier.dll` name collision on Windows.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -27,7 +27,6 @@ environment:
 
     # See: https://www.appveyor.com/docs/installed-software/#python
 
-    - NOX_SESSION: "doctest"
     - NOX_SESSION: "unit-3.6-32"
     - NOX_SESSION: "unit-3.6"
     - NOX_SESSION: "unit-3.7-32"
@@ -35,7 +34,7 @@ environment:
     - NOX_SESSION: "unit-3.8-32"
     - NOX_SESSION: "cover"
     - NOX_SESSION: "functional-3.8"
-    # - NOX_SESSION: "doctest"
+    - NOX_SESSION: "doctest"
 
 install:
   - echo "Filesystem root:"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -27,6 +27,7 @@ environment:
 
     # See: https://www.appveyor.com/docs/installed-software/#python
 
+    - NOX_SESSION: "doctest"
     - NOX_SESSION: "unit-3.6-32"
     - NOX_SESSION: "unit-3.6"
     - NOX_SESSION: "unit-3.7-32"
@@ -34,7 +35,7 @@ environment:
     - NOX_SESSION: "unit-3.8-32"
     - NOX_SESSION: "cover"
     - NOX_SESSION: "functional-3.8"
-    - NOX_SESSION: "doctest"
+    # - NOX_SESSION: "doctest"
 
 install:
   - echo "Filesystem root:"

--- a/DEVELOPMENT.rst
+++ b/DEVELOPMENT.rst
@@ -531,6 +531,10 @@ This project uses environment variables for building the
 - ``BEZIER_NO_EXTENSION``: If set, this will indicate that only the pure
   Python package should be built and installed (i.e. without the binary
   extension).
+- ``BEZIER_WHEEL``: If set, this will indicate to ``setup.py`` that the
+  current build is intended for a wheel. On Windows, this will involve
+  renaming ``bezier.dll`` to a unique name (to avoid name collision) and
+  updating ``_speedup*.pyd`` to refer to the new name.
 
 for interacting with the system at import time:
 

--- a/DEVELOPMENT.rst.template
+++ b/DEVELOPMENT.rst.template
@@ -531,6 +531,10 @@ This project uses environment variables for building the
 - ``BEZIER_NO_EXTENSION``: If set, this will indicate that only the pure
   Python package should be built and installed (i.e. without the binary
   extension).
+- ``BEZIER_WHEEL``: If set, this will indicate to ``setup.py`` that the
+  current build is intended for a wheel. On Windows, this will involve
+  renaming ``bezier.dll`` to a unique name (to avoid name collision) and
+  updating ``_speedup*.pyd`` to refer to the new name.
 
 for interacting with the system at import time:
 

--- a/docs/python/binary-extension.rst
+++ b/docs/python/binary-extension.rst
@@ -223,7 +223,7 @@ it indirectly depends on ``libgfortran``, ``libquadmath`` and ``libgcc_s``:
 Windows
 =======
 
-A single Windows shared library (DLL) is provided: ``extra-dll/bezier.dll``.
+A single Windows shared library (DLL) is provided: ``bezier.dll``.
 The Python extension module (``.pyd`` file) depends directly on this library:
 
 .. testsetup:: windows-extension, windows-dll
@@ -287,7 +287,7 @@ The Python extension module (``.pyd`` file) depends directly on this library:
 
      Image has the following dependencies:
 
-       bezier.dll
+       bezier-e5dbb97a.dll
        python38.dll
        KERNEL32.dll
        VCRUNTIME140.dll
@@ -295,6 +295,11 @@ The Python extension module (``.pyd`` file) depends directly on this library:
        api-ms-win-crt-heap-l1-1-0.dll
        api-ms-win-crt-runtime-l1-1-0.dll
    ...
+
+For built wheels, the dependency will be renamed from ``bezier.dll`` to a
+unique name containing the SHA256 hash of the DLL file (to avoid a name
+collision) and placed in a directory within the ``bezier`` package:
+``extra-dll/bezier-e5dbb97a.dll``.
 
 In order to ensure this DLL can be found, the ``bezier.__config__``
 module adds the ``extra-dll`` directory to the DLL search path on import.
@@ -346,7 +351,7 @@ each of the Fortran submodules:
 
    $ gfortran \
    >   -shared \
-   >   -o extra-dll/bezier.dll \
+   >   -o bezier.dll \
    >   ${OBJ_FILES} \
    >   -Wl,--output-def,bezier.def
 
@@ -361,7 +366,7 @@ provided by MinGW:
 
 .. code-block:: rest
 
-   > dumpbin /dependents .\extra-dll\bezier.dll
+   > dumpbin /dependents ...\bezier.dll
    ...
      Image has the following dependencies:
 
@@ -380,7 +385,7 @@ the ``-static`` flag
    $ gfortran \
    >   -static \
    >   -shared \
-   >   -o extra-dll/bezier.dll \
+   >   -o bezier.dll \
    >   ${OBJ_FILES} \
    >   -Wl,--output-def,bezier.def
 
@@ -391,18 +396,18 @@ on MinGW:
 .. testcode:: windows-dll
    :hide:
 
-   invoke_shell("dumpbin", "/dependents", "extra-dll\\bezier.dll")
+   invoke_shell("dumpbin", "/dependents", "extra-dll\\bezier-e5dbb97a.dll")
 
 .. testoutput:: windows-dll
    :options: +NORMALIZE_WHITESPACE
    :windows-only:
 
-   > dumpbin /dependents extra-dll\bezier.dll
+   > dumpbin /dependents extra-dll\bezier-e5dbb97a.dll
    Microsoft (R) COFF/PE Dumper Version ...
    Copyright (C) Microsoft Corporation.  All rights reserved.
 
 
-   Dump of file extra-dll\bezier.dll
+   Dump of file extra-dll\bezier-e5dbb97a.dll
 
    File Type: DLL
 

--- a/docs/python/binary-extension.rst.template
+++ b/docs/python/binary-extension.rst.template
@@ -223,7 +223,7 @@ it indirectly depends on ``libgfortran``, ``libquadmath`` and ``libgcc_s``:
 Windows
 =======
 
-A single Windows shared library (DLL) is provided: ``extra-dll/bezier.dll``.
+A single Windows shared library (DLL) is provided: ``bezier.dll``.
 The Python extension module (``.pyd`` file) depends directly on this library:
 
 .. testsetup:: windows-extension, windows-dll
@@ -287,7 +287,7 @@ The Python extension module (``.pyd`` file) depends directly on this library:
 
      Image has the following dependencies:
 
-       bezier.dll
+       bezier-e5dbb97a.dll
        python38.dll
        KERNEL32.dll
        VCRUNTIME140.dll
@@ -295,6 +295,11 @@ The Python extension module (``.pyd`` file) depends directly on this library:
        api-ms-win-crt-heap-l1-1-0.dll
        api-ms-win-crt-runtime-l1-1-0.dll
    ...
+
+For built wheels, the dependency will be renamed from ``bezier.dll`` to a
+unique name containing the SHA256 hash of the DLL file (to avoid a name
+collision) and placed in a directory within the ``bezier`` package:
+``extra-dll/bezier-e5dbb97a.dll``.
 
 In order to ensure this DLL can be found, the ``bezier.__config__``
 module adds the ``extra-dll`` directory to the DLL search path on import.
@@ -346,7 +351,7 @@ each of the Fortran submodules:
 
    $ gfortran \
    >   -shared \
-   >   -o extra-dll/bezier.dll \
+   >   -o bezier.dll \
    >   ${{OBJ_FILES}} \
    >   -Wl,--output-def,bezier.def
 
@@ -361,7 +366,7 @@ provided by MinGW:
 
 .. code-block:: rest
 
-   > dumpbin /dependents .\extra-dll\bezier.dll
+   > dumpbin /dependents ...\bezier.dll
    ...
      Image has the following dependencies:
 
@@ -380,7 +385,7 @@ the ``-static`` flag
    $ gfortran \
    >   -static \
    >   -shared \
-   >   -o extra-dll/bezier.dll \
+   >   -o bezier.dll \
    >   ${{OBJ_FILES}} \
    >   -Wl,--output-def,bezier.def
 
@@ -391,18 +396,18 @@ on MinGW:
 .. testcode:: windows-dll
    :hide:
 
-   invoke_shell("dumpbin", "/dependents", "extra-dll\\bezier.dll")
+   invoke_shell("dumpbin", "/dependents", "extra-dll\\bezier-e5dbb97a.dll")
 
 .. testoutput:: windows-dll
    :options: +NORMALIZE_WHITESPACE
    :windows-only:
 
-   > dumpbin /dependents extra-dll\bezier.dll
+   > dumpbin /dependents extra-dll\bezier-e5dbb97a.dll
    Microsoft (R) COFF/PE Dumper Version ...
    Copyright (C) Microsoft Corporation.  All rights reserved.
 
 
-   Dump of file extra-dll\bezier.dll
+   Dump of file extra-dll\bezier-e5dbb97a.dll
 
    File Type: DLL
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -65,6 +65,7 @@ DEBUG_SESSION_NAME = "libbezier-debug"
 RELEASE_SESSION_NAME = "libbezier-release"
 INSTALL_PREFIX_ENV = "BEZIER_INSTALL_PREFIX"
 WHEEL_ENV = "BEZIER_WHEEL"
+DLL_HASH_ENV = "BEZIER_DLL_HASH"
 
 
 def get_path(*names):
@@ -252,7 +253,9 @@ def doctest(session):
         install_prefix = _cmake(session, BUILD_TYPE_RELEASE)
     elif IS_WINDOWS:
         session.install(DEPS["machomachomangler"])
-        install_prefix = install_bezier(session, env={WHEEL_ENV: "true"})
+        install_prefix = install_bezier(
+            session, env={WHEEL_ENV: "true", DLL_HASH_ENV: "e5dbb97a"}
+        )
     else:
         raise OSError("Unknown operating system")
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -252,7 +252,7 @@ def doctest(session):
         install_prefix = _cmake(session, BUILD_TYPE_RELEASE)
     elif IS_WINDOWS:
         session.install(DEPS["machomachomangler"])
-        install_prefix = install_bezier(session)
+        install_prefix = install_bezier(session, env={WHEEL_ENV: "true"})
     else:
         raise OSError("Unknown operating system")
 
@@ -260,11 +260,7 @@ def doctest(session):
     run_args = get_doctest_args(session)
     # Make sure that the root directory is on the Python path so that
     # ``tests`` is import-able.
-    env = {
-        "PYTHONPATH": get_path(),
-        INSTALL_PREFIX_ENV: install_prefix,
-        WHEEL_ENV: "true",
-    }
+    env = {"PYTHONPATH": get_path(), INSTALL_PREFIX_ENV: install_prefix}
     session.run(*run_args, env=env)
 
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -38,6 +38,7 @@ DEPS = {
     "flake8-import-order": "flake8-import-order",
     "jsonschema": "jsonschema >= 3.2.0",
     "lcov_cobertura": "lcov_cobertura",
+    "machomachomangler": "machomachomangler == 0.0.1",
     "matplotlib": "matplotlib >= 3.1.2",
     "numpy": "numpy >= 1.18.1",
     "pycobertura": "pycobertura",
@@ -63,6 +64,7 @@ BUILD_TYPE_RELEASE = "Release"
 DEBUG_SESSION_NAME = "libbezier-debug"
 RELEASE_SESSION_NAME = "libbezier-release"
 INSTALL_PREFIX_ENV = "BEZIER_INSTALL_PREFIX"
+WHEEL_ENV = "BEZIER_WHEEL"
 
 
 def get_path(*names):
@@ -248,13 +250,21 @@ def doctest(session):
         command = get_path("scripts", "nox-install-for-doctest-linux.sh")
         session.run(command, external=True)
         install_prefix = _cmake(session, BUILD_TYPE_RELEASE)
-    else:
+    elif IS_WINDOWS:
+        session.install(DEPS["machomachomangler"])
         install_prefix = install_bezier(session)
+    else:
+        raise OSError("Unknown operating system")
+
     # Run the script for building docs and running doctests.
     run_args = get_doctest_args(session)
     # Make sure that the root directory is on the Python path so that
     # ``tests`` is import-able.
-    env = {"PYTHONPATH": get_path(), INSTALL_PREFIX_ENV: install_prefix}
+    env = {
+        "PYTHONPATH": get_path(),
+        INSTALL_PREFIX_ENV: install_prefix,
+        WHEEL_ENV: "true",
+    }
     session.run(*run_args, env=env)
 
 

--- a/setup.py
+++ b/setup.py
@@ -163,12 +163,12 @@ def copy_dll(build_lib):
     os.makedirs(build_lib_extra_dll, exist_ok=True)
 
     if WHEEL_ENV in os.environ:
-        dll_name = _DLL_FILENAME
-        return_value = None
-    else:
         short_hash = _sha256_short_hash(installed_dll)
         dll_name = f"bezier-{short_hash}.dll"
         return_value = dll_name
+    else:
+        dll_name = _DLL_FILENAME
+        return_value = None
 
     relocated_dll = os.path.join(build_lib_extra_dll, dll_name)
     shutil.copyfile(installed_dll, relocated_dll)

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,9 @@ WHEEL_ENV = "BEZIER_WHEEL"
 If this is present (e.g. ``BEZIER_WHEEL="True"``) then copied DLL on Windows
 will be modified.
 """
+# NOTE: This is a workaround, put in place for "deterministic" hashing of the
+#       DLL in cases where that matters (i.e. ``doctest``.)
+DLL_HASH_ENV = "BEZIER_DLL_HASH"
 REQUIREMENTS = ("numpy >= 1.18.1",)
 EXTRAS_REQUIRE = {
     "full": ["matplotlib >= 3.0.0", "scipy >= 1.4.1", "sympy >= 1.5.1"]
@@ -163,7 +166,11 @@ def copy_dll(build_lib):
     os.makedirs(build_lib_extra_dll, exist_ok=True)
 
     if WHEEL_ENV in os.environ:
-        short_hash = _sha256_short_hash(installed_dll)
+        provided_hash = os.environ.get(DLL_HASH_ENV)
+        if provided_hash is None:
+            short_hash = _sha256_short_hash(installed_dll)
+        else:
+            short_hash = provided_hash
         dll_name = f"bezier-{short_hash}.dll"
         return_value = dll_name
     else:

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,9 @@
 
 """Setup file for ``bezier``."""
 
+import hashlib
 import os
+import pathlib
 import shutil
 import sys
 
@@ -50,12 +52,18 @@ INSTALL_PREFIX_ENV = "BEZIER_INSTALL_PREFIX"
 NO_INSTALL_PREFIX_MESSAGE = (
     "The {} environment variable must be set."
 ).format(INSTALL_PREFIX_ENV)
+WHEEL_ENV = "BEZIER_WHEEL"
+"""Environment variable used to indicate a wheel is being built.
+
+If this is present (e.g. ``BEZIER_WHEEL="True"``) then copied DLL on Windows
+will be modified.
+"""
 REQUIREMENTS = ("numpy >= 1.18.1",)
 EXTRAS_REQUIRE = {
     "full": ["matplotlib >= 3.0.0", "scipy >= 1.4.1", "sympy >= 1.5.1"]
 }
 DESCRIPTION = (
-    u"Helper for B\u00e9zier Curves, Triangles, and Higher Order Objects"
+    "Helper for B\u00e9zier Curves, Triangles, and Higher Order Objects"
 )
 _IS_WINDOWS = os.name == "nt"
 _EXTRA_DLL = "extra-dll"
@@ -80,6 +88,24 @@ def numpy_include_dir():
     import numpy as np
 
     return np.get_include()
+
+
+def _sha256_hash(filename, blocksize=65536):
+    """Hash the contents of an open file handle with SHA256"""
+    hash_obj = hashlib.sha256()
+
+    with open(filename, "rb") as file_obj:
+        block = file_obj.read(blocksize)
+        while block:
+            hash_obj.update(block)
+            block = file_obj.read(blocksize)
+
+    return hash_obj.hexdigest()
+
+
+def _sha256_short_hash(filename):
+    full_hash = _sha256_hash(filename)
+    return full_hash[:8]
 
 
 def extension_modules():
@@ -124,25 +150,64 @@ def make_readme():
 
 def copy_dll(build_lib):
     if not _IS_WINDOWS:
-        return
+        return None
 
     install_prefix = os.environ.get(INSTALL_PREFIX_ENV)
     if install_prefix is None:
-        return
+        return None
 
     # NOTE: ``bin`` is hardcoded here, expected to correspond to
     #       ``CMAKE_INSTALL_BINDIR`` on Windows.
     installed_dll = os.path.join(install_prefix, "bin", _DLL_FILENAME)
     build_lib_extra_dll = os.path.join(build_lib, "bezier", _EXTRA_DLL)
     os.makedirs(build_lib_extra_dll, exist_ok=True)
-    relocated_dll = os.path.join(build_lib_extra_dll, _DLL_FILENAME)
+
+    if WHEEL_ENV in os.environ:
+        dll_name = _DLL_FILENAME
+        return_value = None
+    else:
+        short_hash = _sha256_short_hash(installed_dll)
+        dll_name = f"bezier-{short_hash}.dll"
+        return_value = dll_name
+
+    relocated_dll = os.path.join(build_lib_extra_dll, dll_name)
     shutil.copyfile(installed_dll, relocated_dll)
+
+    return return_value
+
+
+def _find_speedup_pyd(build_lib):
+    bezier_dir = pathlib.Path(build_lib) / "bezier"
+    speedup_glob = "_speedup*.pyd"
+    matches = list(bezier_dir.glob(speedup_glob))
+    if len(matches) != 1:
+        raise ValueError(f"Could not find unique ``{speedup_glob}``", matches)
+
+    return str(matches[0])
+
+
+def rewrite_pyd_reference(dll_name, build_lib):
+    if dll_name is None:
+        return
+
+    import machomachomangler.pe
+
+    speedup_filename = _find_speedup_pyd(build_lib)
+    with open(speedup_filename, "rb") as file_obj:
+        pyd_bytes = file_obj.read()
+
+    new_pyd_bytes = machomachomangler.pe.redll(
+        pyd_bytes, {_DLL_FILENAME.encode("ascii"): dll_name.encode("ascii")}
+    )
+    with open(speedup_filename, "wb") as file_obj:
+        file_obj.write(new_pyd_bytes)
 
 
 class BuildExtWithDLL(setuptools.command.build_ext.build_ext):
     def run(self):
-        copy_dll(self.build_lib)
-        return setuptools.command.build_ext.build_ext.run(self)
+        dll_name = copy_dll(self.build_lib)
+        setuptools.command.build_ext.build_ext.run(self)
+        rewrite_pyd_reference(dll_name, self.build_lib)
 
 
 def setup():

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -76,7 +76,7 @@ def _find_gcc_homebrew():
     gcc_root = gcc_root_bytes.decode("utf-8").rstrip()
     matches = list(pathlib.Path(gcc_root).glob("*/bin/gcc-[0-9]*"))
     if len(matches) != 1:
-        raise ValueError("Could not find unique Homebrew-installed `gcc`")
+        raise ValueError("Could not find unique Homebrew-installed ``gcc``")
     return str(matches[0])
 
 


### PR DESCRIPTION
Does so by renaming `bezier.dll` to include the first 8 characters of the SHA256 hash of the file.

Fixes #189.