### PR TITLE
Delay import of pkg_resources until needed (if ever).

### DIFF
--- a/src/python/bezier/__config__.py
+++ b/src/python/bezier/__config__.py
@@ -18,8 +18,6 @@ path so that the ``libbezier`` DLL can be located.
 
 import os
 
-import pkg_resources
-
 
 # Error messages for ``handle_import_error``.
 TEMPLATE = "No module named 'bezier.{}'"  # 3.6, 3.7, 3.8, pypy3
@@ -57,6 +55,8 @@ def modify_path():
     """
     if os.name != "nt":
         return
+
+    import pkg_resources  # pylint: disable=import-outside-toplevel
 
     try:
         extra_dll_dir = pkg_resources.resource_filename("bezier", "extra-dll")


### PR DESCRIPTION
pkg_resources can be very slow to import (e.g. https://github.com/pypa/setuptools/issues/926).
See rationale re: importance of import time in #194.

Alternatively, one could use importlib.resources on Py3.7+, but
then one needs to add version-conditional code for Py3.6 (or a
version-conditional dependency on importlib_resources).