### PR TITLE
Using `importlib.metadata` to locate `extra-dll` on Windows.

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -36,6 +36,7 @@ DEPS = {
     "docutils": "docutils",
     "flake8": "flake8",
     "flake8-import-order": "flake8-import-order",
+    "importlib-metadata": 'importlib-metadata; :python_version<"3.8"',
     "jsonschema": "jsonschema >= 3.2.0",
     "lcov_cobertura": "lcov_cobertura",
     "machomachomangler": "machomachomangler == 0.0.1",
@@ -50,7 +51,7 @@ DEPS = {
     "sympy": "sympy >= 1.5.1",
     "seaborn": "seaborn >= 0.9.0",
 }
-BASE_DEPS = (DEPS["numpy"], DEPS["pytest"])
+BASE_DEPS = (DEPS["numpy"], DEPS["pytest"], DEPS["importlib-metadata"])
 NOX_DIR = os.path.abspath(os.path.dirname(__file__))
 DOCS_DEPS = (
     "--requirement",
@@ -272,6 +273,7 @@ def docs_images(session):
     # Install all dependencies.
     local_deps = DOCS_DEPS
     local_deps += (
+        DOCS["importlib-metadata"],
         DEPS["matplotlib"],
         DEPS["pytest"],
         DEPS["seaborn"],

--- a/noxfile.py
+++ b/noxfile.py
@@ -36,7 +36,7 @@ DEPS = {
     "docutils": "docutils",
     "flake8": "flake8",
     "flake8-import-order": "flake8-import-order",
-    "importlib-metadata": 'importlib-metadata; :python_version<"3.8"',
+    "importlib-metadata": 'importlib-metadata; python_version<"3.8"',
     "jsonschema": "jsonschema >= 3.2.0",
     "lcov_cobertura": "lcov_cobertura",
     "machomachomangler": "machomachomangler == 0.0.1",

--- a/setup.py
+++ b/setup.py
@@ -62,9 +62,13 @@ will be modified.
 #       DLL in cases where that matters (i.e. ``doctest``.)
 DLL_HASH_ENV = "BEZIER_DLL_HASH"
 REQUIREMENTS = ("numpy >= 1.18.1",)
+# See: https://www.python.org/dev/peps/pep-0508/
+#      Dependency specification for Python Software Packages
 EXTRAS_REQUIRE = {
     "full": ["matplotlib >= 3.0.0", "scipy >= 1.4.1", "sympy >= 1.5.1"],
-    ':python_version<"3.8"': ["importlib-metadata"],
+    ':python_version<"3.8" and platform_system=="Windows"': [
+        "importlib-metadata"
+    ],
 }
 DESCRIPTION = (
     "Helper for B\u00e9zier Curves, Triangles, and Higher Order Objects"

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,8 @@ will be modified.
 DLL_HASH_ENV = "BEZIER_DLL_HASH"
 REQUIREMENTS = ("numpy >= 1.18.1",)
 EXTRAS_REQUIRE = {
-    "full": ["matplotlib >= 3.0.0", "scipy >= 1.4.1", "sympy >= 1.5.1"]
+    "full": ["matplotlib >= 3.0.0", "scipy >= 1.4.1", "sympy >= 1.5.1"],
+    ':python_version<"3.8"': ["importlib-metadata"],
 }
 DESCRIPTION = (
     "Helper for B\u00e9zier Curves, Triangles, and Higher Order Objects"

--- a/tests/unit/test___config__.py
+++ b/tests/unit/test___config__.py
@@ -48,7 +48,8 @@ class Test__get_extra_dll_dir(unittest.TestCase):
         bezier_files = (mock_path1, mock_path2)
 
         extra_dll_dir = self._call_function_under_test(bezier_files)
-        self.assertEqual(extra_dll_dir, str(mock_path2.parent))
+        expected = os.path.sep.join(mock_path2.parent.parts)
+        self.assertEqual(extra_dll_dir, expected)
 
 
 class Test_modify_path(unittest.TestCase):

--- a/tests/unit/test___config__.py
+++ b/tests/unit/test___config__.py
@@ -10,9 +10,45 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+try:
+    import importlib.metadata as importlib_metadata
+except ImportError:  # pragma: NO COVER
+    import importlib_metadata
 import os
+import pathlib
 import unittest
 import unittest.mock
+
+
+MOCK_PACKAGE_PATH = importlib_metadata.PackagePath("extra-dll", "bezier.dll")
+MOCK_PACKAGE_PATH.dist = importlib_metadata.PathDistribution(pathlib.Path(""))
+
+
+class Test__get_extra_dll_dir(unittest.TestCase):
+    @staticmethod
+    def _call_function_under_test(bezier_files):
+        from bezier import __config__
+
+        return __config__._get_extra_dll_dir(bezier_files)
+
+    def test_no_matches(self):
+        with self.assertRaises(ImportError) as exc_info:
+            self._call_function_under_test(())
+
+        expected = ("No DLL directory found", ())
+        self.assertEqual(exc_info.exception.args, expected)
+
+    def test_multiple_choices_with_match(self):
+        mock_path1 = importlib_metadata.PackagePath("bezier", "__config__.py")
+        mock_path1.dist = MOCK_PACKAGE_PATH.dist
+        mock_path2 = importlib_metadata.PackagePath(
+            "bezier", "extra-dll", "bezier.dll"
+        )
+        mock_path2.dist = MOCK_PACKAGE_PATH.dist
+        bezier_files = (mock_path1, mock_path2)
+
+        extra_dll_dir = self._call_function_under_test(bezier_files)
+        self.assertEqual(extra_dll_dir, str(mock_path2.parent))
 
 
 class Test_modify_path(unittest.TestCase):
@@ -29,78 +65,79 @@ class Test_modify_path(unittest.TestCase):
         self.assertEqual(os.environ, {})
 
     @unittest.mock.patch.multiple(os, name="nt", environ={})
-    @unittest.mock.patch(
-        "pkg_resources.resource_filename", side_effect=ImportError
+    @unittest.mock.patch.object(
+        importlib_metadata,
+        "files",
+        side_effect=importlib_metadata.PackageNotFoundError,
     )
-    def test_windows_without_dll(self, resource_filename):
+    def test_windows_without_dll(self, metadata_files):
         return_value = self._call_function_under_test()
         self.assertIsNone(return_value)
         self.assertEqual(os.environ, {})
         # Check mock.
-        resource_filename.assert_called_once_with("bezier", "extra-dll")
+        metadata_files.assert_called_once_with("bezier")
 
     @unittest.mock.patch.multiple(
         os, name="nt", environ={"PATH": "before" + os.pathsep}
     )
     @unittest.mock.patch("os.path.isdir", return_value=True)
-    @unittest.mock.patch(
-        "pkg_resources.resource_filename", return_value="not-a-path"
+    @unittest.mock.patch.object(
+        importlib_metadata, "files", return_value=(MOCK_PACKAGE_PATH,)
     )
     @unittest.mock.patch("bezier.__config__.OS_ADD_DLL_DIRECTORY", new=None)
-    def test_windows_with_dll(self, resource_filename, isdir):
+    def test_windows_with_dll(self, metadata_files, isdir):
         return_value = self._call_function_under_test()
         self.assertIsNone(return_value)
-        expected_path = "before" + os.pathsep + resource_filename.return_value
+        expected_path = "before" + os.pathsep + str(MOCK_PACKAGE_PATH.parent)
         self.assertEqual(os.environ, {"PATH": expected_path})
         # Check mocks.
-        resource_filename.assert_called_once_with("bezier", "extra-dll")
-        isdir.assert_called_once_with(resource_filename.return_value)
+        metadata_files.assert_called_once_with("bezier")
+        isdir.assert_called_once_with("extra-dll")
 
     @unittest.mock.patch.multiple(os, name="nt", environ={})
     @unittest.mock.patch("os.path.isdir", return_value=True)
-    @unittest.mock.patch(
-        "pkg_resources.resource_filename", return_value="not-a-path"
+    @unittest.mock.patch.object(
+        importlib_metadata, "files", return_value=(MOCK_PACKAGE_PATH,)
     )
     @unittest.mock.patch("bezier.__config__.OS_ADD_DLL_DIRECTORY", new=None)
-    def test_windows_with_dll_no_path(self, resource_filename, isdir):
+    def test_windows_with_dll_no_path(self, metadata_files, isdir):
         return_value = self._call_function_under_test()
         self.assertIsNone(return_value)
-        self.assertEqual(os.environ, {"PATH": resource_filename.return_value})
+        expected_path = str(MOCK_PACKAGE_PATH.parent)
+        self.assertEqual(os.environ, {"PATH": expected_path})
         # Check mocks.
-        resource_filename.assert_called_once_with("bezier", "extra-dll")
-        isdir.assert_called_once_with(resource_filename.return_value)
+        metadata_files.assert_called_once_with("bezier")
+        isdir.assert_called_once_with("extra-dll")
 
     @unittest.mock.patch.multiple(os, name="nt", environ={})
     @unittest.mock.patch("os.path.isdir", return_value=True)
-    @unittest.mock.patch(
-        "pkg_resources.resource_filename", return_value="not-a-path"
+    @unittest.mock.patch.object(
+        importlib_metadata, "files", return_value=(MOCK_PACKAGE_PATH,)
     )
     @unittest.mock.patch("bezier.__config__.OS_ADD_DLL_DIRECTORY")
     def test_windows_with_dll_at_least_38(
-        self, os_add_dll_directory, resource_filename, isdir
+        self, os_add_dll_directory, metadata_files, isdir
     ):
         return_value = self._call_function_under_test()
         self.assertIsNone(return_value)
         self.assertEqual(os.environ, {})
         # Check mocks.
-        resource_filename.assert_called_once_with("bezier", "extra-dll")
-        isdir.assert_called_once_with(resource_filename.return_value)
-        os_add_dll_directory.assert_called_once_with(
-            resource_filename.return_value
-        )
+        metadata_files.assert_called_once_with("bezier")
+        isdir.assert_called_once_with("extra-dll")
+        os_add_dll_directory.assert_called_once_with("extra-dll")
 
     @unittest.mock.patch.multiple(os, name="nt", environ={})
     @unittest.mock.patch("os.path.isdir", return_value=False)
-    @unittest.mock.patch(
-        "pkg_resources.resource_filename", return_value="not-a-path"
+    @unittest.mock.patch.object(
+        importlib_metadata, "files", return_value=(MOCK_PACKAGE_PATH,)
     )
-    def test_windows_with_dll_but_not_a_dir(self, resource_filename, isdir):
+    def test_windows_with_dll_but_not_a_dir(self, metadata_files, isdir):
         return_value = self._call_function_under_test()
         self.assertIsNone(return_value)
         self.assertEqual(os.environ, {})
         # Check mocks.
-        resource_filename.assert_called_once_with("bezier", "extra-dll")
-        isdir.assert_called_once_with(resource_filename.return_value)
+        metadata_files.assert_called_once_with("bezier")
+        isdir.assert_called_once_with("extra-dll")
 
 
 class Test_handle_import_error(unittest.TestCase):


### PR DESCRIPTION
Fixes #206.

/cc @anntzer 