### PR TITLE
Don't throw `ImportError` if `extra-dll` is absent on Windows.

### DIFF
--- a/docs/releases/latest.rst
+++ b/docs/releases/latest.rst
@@ -6,6 +6,17 @@ Latest Release (``2021.2.13.dev1``)
 Python Changes
 --------------
 
+Bug Fixes
+~~~~~~~~~
+
+-  Allow the ``extra-dll`` directory to be absent on Windows. For binary wheel
+   installs, this directory contains the ``libbezier`` DLL (e.g.
+   ``extra-dll\bezier-2a44d276.dll`` was in the most recent release for 64-bit
+   Python 3.9). For pure Python installs, the ``extra-dll`` directory will
+   be absent.
+   (`#255 <https://github.com/dhermes/bezier/pull/255>`__). Fixed
+   `#254 <https://github.com/dhermes/bezier/issues/254>`__.
+
 Breaking Changes
 ~~~~~~~~~~~~~~~~
 

--- a/src/python/bezier/__config__.py
+++ b/src/python/bezier/__config__.py
@@ -69,10 +69,8 @@ def _get_extra_dll_dir(bezier_files):
             paths.
 
     Returns:
-        str: The path of the matching ``extra-dll`` directory.
-
-    Raises:
-        ImportError: If no match can be found.
+        Optional[str]: The path of the matching ``extra-dll`` directory, or
+        :data:`None` if no match can be found.
     """
     for path in bezier_files:
         if not _is_extra_dll(path):
@@ -81,7 +79,7 @@ def _get_extra_dll_dir(bezier_files):
         absolute_path = path.locate()
         return str(absolute_path.parent)
 
-    raise ImportError("No DLL directory found", bezier_files)
+    return None
 
 
 def modify_path():
@@ -107,6 +105,8 @@ def modify_path():
         return
 
     extra_dll_dir = _get_extra_dll_dir(bezier_files)
+    if extra_dll_dir is None:
+        return
     add_dll_directory(extra_dll_dir)
 
 

--- a/tests/unit/test___config__.py
+++ b/tests/unit/test___config__.py
@@ -32,11 +32,8 @@ class Test__get_extra_dll_dir(unittest.TestCase):
         return __config__._get_extra_dll_dir(bezier_files)
 
     def test_no_matches(self):
-        with self.assertRaises(ImportError) as exc_info:
-            self._call_function_under_test(())
-
-        expected = ("No DLL directory found", ())
-        self.assertEqual(exc_info.exception.args, expected)
+        extra_dll_dir = self._call_function_under_test(())
+        self.assertIsNone(extra_dll_dir)
 
     def test_multiple_choices_with_match(self):
         mock_path1 = importlib_metadata.PackagePath("bezier", "__config__.py")

--- a/tests/unit/test___config__.py
+++ b/tests/unit/test___config__.py
@@ -68,6 +68,19 @@ class Test_modify_path(unittest.TestCase):
         "files",
         side_effect=importlib_metadata.PackageNotFoundError,
     )
+    def test_windows_without_package(self, metadata_files):
+        return_value = self._call_function_under_test()
+        self.assertIsNone(return_value)
+        self.assertEqual(os.environ, {})
+        # Check mock.
+        metadata_files.assert_called_once_with("bezier")
+
+    @unittest.mock.patch.multiple(os, name="nt", environ={})
+    @unittest.mock.patch.object(
+        importlib_metadata,
+        "files",
+        return_value=(),
+    )
     def test_windows_without_dll(self, metadata_files):
         return_value = self._call_function_under_test()
         self.assertIsNone(return_value)


### PR DESCRIPTION
Fixes #254.