### PR TITLE
Release `2023.7.28`.

### DIFF
--- a/DEVELOPMENT.rst
+++ b/DEVELOPMENT.rst
@@ -58,7 +58,7 @@ Binary Extension
 Many low-level computations have alternate implementations in Fortran.
 See the `Python Binary Extension`_ page for a more detailed description.
 
-.. _Python Binary Extension: https://bezier.readthedocs.io/en/latest/python/binary-extension.html
+.. _Python Binary Extension: https://bezier.readthedocs.io/en/2023.7.28/python/binary-extension.html
 
 Building / Compiling
 ====================
@@ -100,7 +100,7 @@ This code is Public Domain, so does not conflict with the Apache 2.0 license
 QUADPACK is used to perform numerical quadrature to compute the length
 of a curve segment.
 
-.. _file: https://github.com/dhermes/bezier/tree/main/src/fortran/quadpack.f90
+.. _file: https://github.com/dhermes/bezier/tree/2023.7.28/src/fortran/quadpack.f90
 .. _QUADPACK: https://en.wikipedia.org/wiki/QUADPACK
 .. _John Burkardt: https://people.math.sc.edu/Burkardt/f_src/quadpack_double/quadpack_double.html
 
@@ -266,32 +266,32 @@ To run the functional tests:
    $ PYTHONPATH=src/python/ python3.11 -m pytest tests/functional/
    $ PYTHONPATH=src/python/ pypy3      -m pytest tests/functional/
 
-.. _functional tests: https://github.com/dhermes/bezier/tree/main/tests/functional
+.. _functional tests: https://github.com/dhermes/bezier/tree/2023.7.28/tests/functional
 
 For example, the following curve-curve intersection is a
 functional test case:
 
-.. image:: https://raw.githubusercontent.com/dhermes/bezier/main/docs/images/curves11_and_26.png
+.. image:: https://raw.githubusercontent.com/dhermes/bezier/2023.7.28/docs/images/curves11_and_26.png
    :align: center
 
 and there is a `Curve-Curve Intersection`_ document which captures many of
 the cases in the functional tests.
 
-.. _Curve-Curve Intersection: https://bezier.readthedocs.io/en/latest/algorithms/curve-curve-intersection.html
+.. _Curve-Curve Intersection: https://bezier.readthedocs.io/en/2023.7.28/algorithms/curve-curve-intersection.html
 
 A triangle-triangle intersection functional test case:
 
-.. image:: https://raw.githubusercontent.com/dhermes/bezier/main/docs/images/triangles1Q_and_2Q.png
+.. image:: https://raw.githubusercontent.com/dhermes/bezier/2023.7.28/docs/images/triangles1Q_and_2Q.png
    :align: center
 
 a segment-box functional test case:
 
-.. image:: https://raw.githubusercontent.com/dhermes/bezier/main/docs/images/test_goes_through_box08.png
+.. image:: https://raw.githubusercontent.com/dhermes/bezier/2023.7.28/docs/images/test_goes_through_box08.png
    :align: center
 
 and a "locate point on triangle" functional test case:
 
-.. image:: https://raw.githubusercontent.com/dhermes/bezier/main/docs/images/test_triangle3_and_point1.png
+.. image:: https://raw.githubusercontent.com/dhermes/bezier/2023.7.28/docs/images/test_triangle3_and_point1.png
    :align: center
 
 Functional Test Data
@@ -309,10 +309,10 @@ This way, the test cases are programming language agnostic and can be
 repurposed. The `JSON schema`_ for these files are stored in the
 ``tests/functional/schema`` directory.
 
-.. _curves.json: https://github.com/dhermes/bezier/blob/main/tests/functional/curves.json
-.. _curve_intersections.json: https://github.com/dhermes/bezier/blob/main/tests/functional/curve_intersections.json
-.. _triangles.json: https://github.com/dhermes/bezier/blob/main/tests/functional/triangles.json
-.. _triangle_intersections.json: https://github.com/dhermes/bezier/blob/main/tests/functional/triangle_intersections.json
+.. _curves.json: https://github.com/dhermes/bezier/blob/2023.7.28/tests/functional/curves.json
+.. _curve_intersections.json: https://github.com/dhermes/bezier/blob/2023.7.28/tests/functional/curve_intersections.json
+.. _triangles.json: https://github.com/dhermes/bezier/blob/2023.7.28/tests/functional/triangles.json
+.. _triangle_intersections.json: https://github.com/dhermes/bezier/blob/2023.7.28/tests/functional/triangle_intersections.json
 .. _JSON schema: http://json-schema.org/
 
 ************
@@ -335,7 +335,7 @@ To check compliance:
 A few extensions and overrides have been specified in the `pylintrc`_
 configuration for ``bezier``.
 
-.. _pylintrc: https://github.com/dhermes/bezier/blob/main/pylintrc
+.. _pylintrc: https://github.com/dhermes/bezier/blob/2023.7.28/pylintrc
 
 Docstring Style
 ===============
@@ -449,11 +449,11 @@ Python versions we test in. The image used in our Linux builds (from
 ``nox`` and NumPy).
 
 .. _GitHub Actions: https://github.com/dhermes/bezier/actions
-.. _Linux config: https://github.com/dhermes/bezier/blob/main/.github/workflows/linux.yaml
-.. _macOS config: https://github.com/dhermes/bezier/blob/main/.github/workflows/macos.yaml
-.. _Windows config: https://github.com/dhermes/bezier/blob/main/.github/workflows/windows.yaml
+.. _Linux config: https://github.com/dhermes/bezier/blob/2023.7.28/.github/workflows/linux.yaml
+.. _macOS config: https://github.com/dhermes/bezier/blob/2023.7.28/.github/workflows/macos.yaml
+.. _Windows config: https://github.com/dhermes/bezier/blob/2023.7.28/.github/workflows/windows.yaml
 .. _python-multi Dockerfile: https://github.com/dhermes/python-multi/blob/master/src/Dockerfile
-.. _bezier Dockerfile: https://github.com/dhermes/bezier/blob/main/scripts/docker/bezier.Dockerfile
+.. _bezier Dockerfile: https://github.com/dhermes/bezier/blob/2023.7.28/scripts/docker/bezier.Dockerfile
 
 ****************************************
 Release Process / Deploying New Versions
@@ -486,7 +486,7 @@ reasons:
 .. _PyPI: https://pypi.org/project/bezier/
 .. _twine: https://packaging.python.org/distributing/
 .. _TestPyPI: https://packaging.python.org/guides/using-testpypi/
-.. _Building Wheels workflow: https://github.com/dhermes/bezier/blob/main/.github/workflows/wheels.yaml
+.. _Building Wheels workflow: https://github.com/dhermes/bezier/blob/2023.7.28/.github/workflows/wheels.yaml
 
 Supported Python Versions
 =========================
@@ -507,7 +507,7 @@ Supported Python Versions
 
 Supported versions can be found in the ``noxfile.py`` `config`_.
 
-.. _config: https://github.com/dhermes/bezier/blob/main/noxfile.py
+.. _config: https://github.com/dhermes/bezier/blob/2023.7.28/noxfile.py
 
 Versioning
 ==========

--- a/README.rst
+++ b/README.rst
@@ -5,8 +5,6 @@
 
 |linux-build| |macos-build| |windows-build| |coverage|
 
-|pypi| |versions|
-
 |docs| |zenodo| |JOSS|
 
 .. |eacute| unicode:: U+000E9 .. LATIN SMALL LETTER E WITH ACUTE
@@ -19,7 +17,7 @@ This library provides:
 
 Dive in and take a look!
 
-.. image:: https://raw.githubusercontent.com/dhermes/bezier/main/docs/images/triangles6Q_and_7Q.png
+.. image:: https://raw.githubusercontent.com/dhermes/bezier/2023.7.28/docs/images/triangles6Q_and_7Q.png
    :align: center
 
 Why B |eacute| zier?
@@ -28,17 +26,17 @@ Why B |eacute| zier?
 A B |eacute| zier curve (and triangle, etc.) is a parametric curve
 that uses the `Bernstein basis`_:
 
-.. image:: https://raw.githubusercontent.com/dhermes/bezier/main/docs/images/bernstein_basis.png
+.. image:: https://raw.githubusercontent.com/dhermes/bezier/2023.7.28/docs/images/bernstein_basis.png
    :align: center
 
 to define a curve as a linear combination:
 
-.. image:: https://raw.githubusercontent.com/dhermes/bezier/main/docs/images/bezier_defn.png
+.. image:: https://raw.githubusercontent.com/dhermes/bezier/2023.7.28/docs/images/bezier_defn.png
    :align: center
 
 This comes from the fact that the weights sum to one:
 
-.. image:: https://raw.githubusercontent.com/dhermes/bezier/main/docs/images/sum_to_unity.png
+.. image:: https://raw.githubusercontent.com/dhermes/bezier/2023.7.28/docs/images/sum_to_unity.png
    :align: center
 
 This can be generalized to higher order by considering three, four, etc.
@@ -148,7 +146,7 @@ intersections):
    >>> _ = ax.set_xlim(-0.125, 1.125)
    >>> _ = ax.set_ylim(-0.0625, 0.625)
 
-.. image:: https://raw.githubusercontent.com/dhermes/bezier/main/docs/images/curves1_and_13.png
+.. image:: https://raw.githubusercontent.com/dhermes/bezier/2023.7.28/docs/images/curves1_and_13.png
    :align: center
 
 For API-level documentation, check out the B |eacute| zier Python
@@ -195,32 +193,26 @@ License
 ``bezier`` is made available under the Apache 2.0 License. For more
 details, see `the LICENSE`_.
 
-.. _Curves: https://bezier.readthedocs.io/en/latest/python/reference/bezier.curve.html
-.. _Triangles: https://bezier.readthedocs.io/en/latest/python/reference/bezier.triangle.html
-.. _package: https://bezier.readthedocs.io/en/latest/python/reference/bezier.html
-.. _DEVELOPMENT doc: https://github.com/dhermes/bezier/blob/main/DEVELOPMENT.rst
-.. _the LICENSE: https://github.com/dhermes/bezier/blob/main/LICENSE
+.. _Curves: https://bezier.readthedocs.io/en/2023.7.28/python/reference/bezier.curve.html
+.. _Triangles: https://bezier.readthedocs.io/en/2023.7.28/python/reference/bezier.triangle.html
+.. _package: https://bezier.readthedocs.io/en/2023.7.28/python/reference/bezier.html
+.. _DEVELOPMENT doc: https://github.com/dhermes/bezier/blob/2023.7.28/DEVELOPMENT.rst
+.. _the LICENSE: https://github.com/dhermes/bezier/blob/2023.7.28/LICENSE
 
-.. |docs| image:: https://readthedocs.org/projects/bezier/badge/?version=latest
-   :target: https://bezier.readthedocs.io/en/latest/
+.. |docs| image:: https://readthedocs.org/projects/bezier/badge/?version=2023.7.28
+   :target: https://bezier.readthedocs.io/en/2023.7.28/
    :alt: Documentation Status
-.. |linux-build| image:: https://github.com/dhermes/bezier/workflows/Linux/badge.svg?branch=main&event=push
-   :target: https://github.com/dhermes/bezier/actions?query=workflow%3ALinux
+.. |linux-build| image:: https://raw.githubusercontent.com/dhermes/bezier/2023.7.28/docs/linux-passing.svg?sanitize=true
+   :target: https://github.com/dhermes/bezier/actions/runs/5698156661
    :alt: Linux Build (GitHub Actions)
-.. |macos-build| image:: https://github.com/dhermes/bezier/workflows/macOS/badge.svg?branch=main&event=push
-   :target: https://github.com/dhermes/bezier/actions?query=workflow%3AmacOS
+.. |macos-build| image:: https://raw.githubusercontent.com/dhermes/bezier/2023.7.28/docs/macos-passing.svg?sanitize=true
+   :target: https://github.com/dhermes/bezier/actions/runs/5698156663
    :alt: macOS Build (GitHub Actions)
-.. |windows-build| image:: https://github.com/dhermes/bezier/workflows/Windows/badge.svg?branch=main&event=push
-   :target: https://github.com/dhermes/bezier/actions?query=workflow%3AWindows
+.. |windows-build| image:: https://raw.githubusercontent.com/dhermes/bezier/2023.7.28/docs/windows-passing.svg?sanitize=true
+   :target: https://github.com/dhermes/bezier/actions/run/5698156662
    :alt: Windows Build (GitHub Actions)
-.. |pypi| image:: https://img.shields.io/pypi/v/bezier.svg
-   :target: https://pypi.org/project/bezier/
-   :alt: PyPI Latest
-.. |versions| image:: https://img.shields.io/pypi/pyversions/bezier.svg
-   :target: https://pypi.org/project/bezier/
-   :alt: Package Versions
-.. |coverage| image:: https://coveralls.io/repos/github/dhermes/bezier/badge.svg
-   :target: https://coveralls.io/github/dhermes/bezier
+.. |coverage| image:: https://s3.amazonaws.com/assets.coveralls.io/badges/coveralls_100.svg
+   :target: https://coveralls.io/builds/61654285
    :alt: Code Coverage
 .. |zenodo| image:: https://zenodo.org/badge/73047402.svg
    :target: https://zenodo.org/badge/latestdoi/73047402

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,8 +5,6 @@
 
 |linux-build| |macos-build| |windows-build| |coverage|
 
-|pypi| |versions|
-
 |zenodo| |JOSS|
 
 .. |eacute| unicode:: U+000E9 .. LATIN SMALL LETTER E WITH ACUTE
@@ -252,25 +250,19 @@ License
 ``bezier`` is made available under the Apache 2.0 License. For more
 details, see `the LICENSE`_.
 
-.. _the LICENSE: https://github.com/dhermes/bezier/blob/main/LICENSE
+.. _the LICENSE: https://github.com/dhermes/bezier/blob/2023.7.28/LICENSE
 
-.. |linux-build| image:: https://github.com/dhermes/bezier/workflows/Linux/badge.svg?branch=main&event=push
-   :target: https://github.com/dhermes/bezier/actions?query=workflow%3ALinux
+.. |linux-build| image:: https://raw.githubusercontent.com/dhermes/bezier/2023.7.28/docs/linux-passing.svg?sanitize=true
+   :target: https://github.com/dhermes/bezier/actions/runs/5698156661
    :alt: Linux Build (GitHub Actions)
-.. |macos-build| image:: https://github.com/dhermes/bezier/workflows/macOS/badge.svg?branch=main&event=push
-   :target: https://github.com/dhermes/bezier/actions?query=workflow%3AmacOS
+.. |macos-build| image:: https://raw.githubusercontent.com/dhermes/bezier/2023.7.28/docs/macos-passing.svg?sanitize=true
+   :target: https://github.com/dhermes/bezier/actions/runs/5698156663
    :alt: macOS Build (GitHub Actions)
-.. |windows-build| image:: https://github.com/dhermes/bezier/workflows/Windows/badge.svg?branch=main&event=push
-   :target: https://github.com/dhermes/bezier/actions?query=workflow%3AWindows
+.. |windows-build| image:: https://raw.githubusercontent.com/dhermes/bezier/2023.7.28/docs/windows-passing.svg?sanitize=true
+   :target: https://github.com/dhermes/bezier/actions/runs/5698156662
    :alt: Windows Build (GitHub Actions)
-.. |pypi| image:: https://img.shields.io/pypi/v/bezier.svg
-   :target: https://pypi.org/project/bezier/
-   :alt: PyPI Latest
-.. |versions| image:: https://img.shields.io/pypi/pyversions/bezier.svg
-   :target: https://pypi.org/project/bezier/
-   :alt: Package Versions
-.. |coverage| image:: https://coveralls.io/repos/github/dhermes/bezier/badge.svg
-   :target: https://coveralls.io/github/dhermes/bezier
+.. |coverage| image:: https://s3.amazonaws.com/assets.coveralls.io/badges/coveralls_100.svg
+   :target: https://coveralls.io/builds/61654285
    :alt: Code Coverage
 .. |zenodo| image:: https://zenodo.org/badge/73047402.svg
    :target: https://zenodo.org/badge/latestdoi/73047402


### PR DESCRIPTION
I made sure the templates are populated correctly via:

```
$ python scripts/doc_template_release.py
Linux GitHub Actions Run ID: 5698156661
Windows GitHub Actions Run ID: 5698156662
Coveralls Build ID: 61654285
macOS GitHub Actions Run ID: 5698156663
```

I'll be using this PR to post comments about the release process (for audit purposes).