### PR TITLE
Support `musllinux`

### DIFF
--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -69,7 +69,6 @@ jobs:
             TARGET_NATIVE_ARCH=OFF
           CIBW_TEST_COMMAND: pytest {project}/tests/unit
           CIBW_TEST_REQUIRES: pytest
-          CIBW_SKIP: "*musllinux*"
 
       - uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
This is still a WIP, running the following currently segaults:

```bash
#!/bin/bash

set -e -x

export CIBW_ARCHS=x86_64
export CIBW_BEFORE_BUILD='python -m pip install cmake nox numpy; nox --session libbezier-release'
export CIBW_BUILD='cp311*musllinux*'
export CIBW_ENVIRONMENT='BEZIER_INSTALL_PREFIX=/project/.nox/.cache/libbezier-release/usr LD_LIBRARY_PATH=/project/.nox/.cache/libbezier-release/usr/lib TARGET_NATIVE_ARCH=OFF'
export CIBW_TEST_COMMAND='pytest {project}/tests/unit'
export CIBW_TEST_REQUIRES=pytest
cibuildwheel --platform linux
```